### PR TITLE
[feat]: Implement real-time emoji editing and introduce build variants

### DIFF
--- a/.github/scripts/upload.py
+++ b/.github/scripts/upload.py
@@ -6,47 +6,69 @@ apiAddress = "http://127.0.0.1:8081/"
 urlPrefix = apiAddress + "bot" + os.getenv("TELEGRAM_TOKEN")
 
 
-def findString(sourceStr, targetStr):
-    if str(sourceStr).find(str(targetStr)) == -1:
-        return False
-    else:
-        return True
+def sendMediaGroup(user_id, paths):
+    url = urlPrefix + "/sendMediaGroup"
+    files = {}
+    media = []
 
+    for i, path in enumerate(paths):
+        file_key = f'file{i}'
+        files[file_key] = open(path, 'rb')
+        media_item = {
+            'type': 'document',
+            'media': f'attach://{file_key}'
+        }
+        media.append(media_item)
 
-def genFileDirectory(path):
-    files_walk = os.walk(path)
-    target = {
+    data = {
+        'chat_id': user_id,
+        'media': json.dumps(media)
     }
-    for root, dirs, file_name_dic in files_walk:
-        for fileName in file_name_dic:
-            if findString(fileName, "v8a"):
-                target["arm64"] = (fileName, open(path + "/" + fileName, "rb"))
-            if findString(fileName, "v7a"):
-                target["armeabi"] = (fileName, open(path + "/" + fileName, "rb"))
-            if findString(fileName, "x86.apk"):
-                target["i386"] = (fileName, open(path + "/" + fileName, "rb"))
-            if findString(fileName, "x86_64"):
-                target["amd64"] = (fileName, open(path + "/" + fileName, "rb"))
 
-    return target
+    response = requests.post(url, files=files, data=data)
+    print("MediaGroup Response:", response.json())
+
+    for f in files.values():
+        f.close()
 
 
-def sendDocument(user_id, path, message = "", entities = None):
-    files = {'document': open(path, 'rb')}
-    data = {'chat_id': user_id,
-            'caption': message,
-            'parse_mode': 'Markdown',
-            'caption_entities': entities}
-    response = requests.post(urlPrefix + "/sendDocument", files=files, data=data)
-    print(response.json())
+def sendTextMessage(user_id, message, disable_preview=False):
+    url = urlPrefix + "/sendMessage"
+
+    data = {
+        'chat_id': user_id,
+        'text': message,
+        'parse_mode': 'Markdown',
+        'disable_web_page_preview': disable_preview
+    }
+    response = requests.post(url, data=data)
+
+    response_data = response.json()
 
 
-def sendAPKs(path):
-    apks = os.listdir("apks")
-    apks.sort()
-    apk = os.path.join("apks", apks[0])
-    sendDocument(user_id="@maaryIsTyping", path = apk, message="#app #apk #FaceMoji https://github.com/Steve-Mr/EmojiFace")
 
 if __name__ == '__main__':
-    sendAPKs("./apks")
+    # 从环境变量中获取两个 APK 文件的路径
+    apk_path1 = os.getenv("APK_FILE_UPLOAD1")
+    apk_path2 = os.getenv("APK_FILE_UPLOAD2")
 
+    # 检查路径是否存在
+    if not apk_path1 or not apk_path2:
+        print("错误：未能在环境变量中找到 APK 文件路径。")
+        exit(1)
+
+    # 将两个 APK 路径放入一个列表
+    apk_paths = [apk_path1, apk_path2]
+
+    # 从环境变量中获取版本信息和提交信息来构建消息内容
+    version_name = os.getenv("VERSION_NAME", "N/A")
+    commit_message = os.getenv("COMMIT_MESSAGE", "无提交信息。")
+
+    message = (
+        f"#app #apk #facemoji\n"
+        f"**版本:** `{version_name}`\n\n"
+        f"https://github.com/Steve-Mr/EmojiFace"
+    )
+
+    sendMediaGroup(user_id="@maaryIsTyping", paths=apk_paths)
+    sendTextMessage(user_id="@maaryIsTyping", message=message, disable_preview=True)

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -41,28 +41,28 @@ jobs:
         run: |
           ./gradlew :app:assembleRelease
           
-          echo "APK_FILE=$(find app/build/outputs/apk -name '*arm64*.apk')" >> $GITHUB_ENV
-          echo "APK_FILE_ARMV7=$(find app/build/outputs/apk -name '*v7a*.apk')" >> $GITHUB_ENV
-          echo "APK_FILE_X86=$(find app/build/outputs/apk -name '*x86\-*.apk')" >> $GITHUB_ENV
-          echo "APK_FILE_X64=$(find app/build/outputs/apk -name '*x86\_64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_ARMV8_ICON_ENABLED=$(find app/build/outputs/apk -name '*default-arm64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_UNI_ICON_ENABLED=$(find app/build/outputs/apk -name '*default-universal*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_ARMV8_ICON_DISABLED=$(find app/build/outputs/apk -name '*disabled-arm64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_UNI_ICON_DISABLED=$(find app/build/outputs/apk -name '*disabled-universal*.apk')" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v4
-        name: Upload apk (arm64-v8a)
+        name: Upload apk (icon-enabled-arm64-v8a)
         with:
-          name: app-arm64-v8a-release
-          path: ${{ env.APK_FILE }}
+          name: facemoji-default-arm64-v8a.apk
+          path: ${{ env.APK_FILE_ARMV8_ICON_ENABLED }}
       - uses: actions/upload-artifact@v4
-        name: Upload apk (armeabi-v7a)
+        name: Upload apk (icon-enabled-universal)
         with:
-          name: app-armeabi-v7a-release
-          path: ${{ env.APK_FILE_ARMV7 }}
+          name: facemoji-default-universal.apk
+          path: ${{ env.APK_FILE_UNI_ICON_ENABLED }}
       - uses: actions/upload-artifact@v4
-        name: Upload apk (x86_64)
+        name: Upload apk (icon-disabled-arm64-v8a)
         with:
-          name: app-x86_64-release
-          path: ${{ env.APK_FILE_X64 }}
+          name: facemoji-icon-disabled-arm64-v8a.apk
+          path: ${{ env.APK_FILE_ARMV8_ICON_DISABLED }}
       - uses: actions/upload-artifact@v4
-        name: Upload apk (x86)
+        name: Upload apk (icon-disabled-universal)
         with:
-          name: app-x86-release
-          path: ${{ env.APK_FILE_X86 }}
+          name: facemoji-icon-disabled-universal.apk
+          path: ${{ env.APK_FILE_UNI_ICON_DISABLED }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         id: apk
         uses: JantHsueh/get-apk-info-action@master
         with:
-          apkPath: ${{ env.APK_FILE_UPLOAD }}
+          apkPath: ${{ env.APK_FILE_UPLOAD1 }}
 
       - name: Release
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,31 +41,31 @@ jobs:
         run: |
           ./gradlew :app:assembleRelease
           
-          echo "APK_FILE=$(find app/build/outputs/apk -name '*arm64*.apk')" >> $GITHUB_ENV
-          echo "APK_FILE_ARMV7=$(find app/build/outputs/apk -name '*v7a*.apk')" >> $GITHUB_ENV
-          echo "APK_FILE_X86=$(find app/build/outputs/apk -name '*x86\-*.apk')" >> $GITHUB_ENV
-          echo "APK_FILE_X64=$(find app/build/outputs/apk -name '*x86\_64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_ARMV8_ICON_ENABLED=$(find app/build/outputs/apk -name '*default-arm64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_UNI_ICON_ENABLED=$(find app/build/outputs/apk -name '*default-universal*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_ARMV8_ICON_DISABLED=$(find app/build/outputs/apk -name '*disabled-arm64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_UNI_ICON_DISABLED=$(find app/build/outputs/apk -name '*disabled-universal*.apk')" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v4
-        name: Upload apk (arm64-v8a)
+        name: Upload apk (icon-enabled-arm64-v8a)
         with:
-          name: app-arm64-v8a-release
-          path: ${{ env.APK_FILE }}
+          name: facemoji-default-arm64-v8a.apk
+          path: ${{ env.APK_FILE_ARMV8_ICON_ENABLED }}
       - uses: actions/upload-artifact@v4
-        name: Upload apk (armeabi-v7a)
+        name: Upload apk (icon-enabled-universal)
         with:
-          name: app-armeabi-v7a-release
-          path: ${{ env.APK_FILE_ARMV7 }}
+          name: facemoji-default-universal.apk
+          path: ${{ env.APK_FILE_UNI_ICON_ENABLED }}
       - uses: actions/upload-artifact@v4
-        name: Upload apk (x86_64)
+        name: Upload apk (icon-disabled-arm64-v8a)
         with:
-          name: app-x86_64-release
-          path: ${{ env.APK_FILE_X64 }}
+          name: facemoji-icon-disabled-arm64-v8a.apk
+          path: ${{ env.APK_FILE_ARMV8_ICON_DISABLED }}
       - uses: actions/upload-artifact@v4
-        name: Upload apk (x86)
+        name: Upload apk (icon-disabled-universal)
         with:
-          name: app-x86-release
-          path: ${{ env.APK_FILE_X86 }}
+          name: facemoji-icon-disabled-universal.apk
+          path: ${{ env.APK_FILE_UNI_ICON_DISABLED }}
 
       - name: Get current date
         id: date
@@ -89,51 +89,52 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: release-${{ steps.date.outputs.date }}-${{ steps.release_count.outputs.count }}
-          release_name: Release ${{ steps.date.outputs.date }} 
+          release_name: Release ${{ steps.date.outputs.date }}
+          prerelease: true
           body: |
             ## Changes
             ${{ github.event.pull_request.body }}
             ${{ steps.show_pr_commits.outputs.commits }}
 
       - uses: actions/upload-release-asset@v1
-        name: Upload apk (arm64-v8a)
+        name: Upload Release APK (iconEnabled, arm64-v8a)
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: FaceMoji-arm64-v8a.apk
-          asset_path: ${{ env.APK_FILE }}
-          asset_content_type: application/zip
+          asset_path: ${{ env.APK_FILE_ARMV8_ICON_ENABLED }}
+          asset_name: facemoji-default-arm64-v8a.apk
+          asset_content_type: application/vnd.android.package-archive
 
       - uses: actions/upload-release-asset@v1
-        name: Upload apk (armeabi-v7a)
+        name: Upload Release APK (iconEnabled, universal)
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: FaceMoji-armeabi-v7a.apk
-          asset_path: ${{ env.APK_FILE_ARMV7 }}
-          asset_content_type: application/zip
+          asset_path: ${{ env.APK_FILE_UNI_ICON_ENABLED }}
+          asset_name: facemoji-default-universal.apk
+          asset_content_type: application/vnd.android.package-archive
 
       - uses: actions/upload-release-asset@v1
-        name: Upload apk (x86_64)
+        name: Upload Release APK (iconDisabled, arm64-v8a)
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: FaceMoji-x86_64.apk
-          asset_path: ${{ env.APK_FILE_X64 }}
-          asset_content_type: application/zip
+          asset_path: ${{ env.APK_FILE_ARMV8_ICON_DISABLED }}
+          asset_name: facemoji-icon-disabled-arm64-v8a.apk
+          asset_content_type: application/vnd.android.package-archive
 
       - uses: actions/upload-release-asset@v1
-        name: Upload apk (x86)
+        name: Upload Release APK (iconDisabled, universal)
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: FaceMoji-x86.apk
-          asset_path: ${{ env.APK_FILE_X86 }}
-          asset_content_type: application/zip
+          asset_path: ${{ env.APK_FILE_UNI_ICON_DISABLED }}
+          asset_name: facemoji-icon-disabled-universal.apk
+          asset_content_type: application/vnd.android.package-archive
 
 
   upload:
@@ -157,7 +158,8 @@ jobs:
         run: |
           mkdir apks
           find artifacts -name "*.apk" -exec cp {} apks \;
-          echo "APK_FILE_UPLOAD=$(find apks -name '*arm64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_UPLOAD1=$(find apks -name '*default-arm64*.apk')" >> $GITHUB_ENV
+          echo "APK_FILE_UPLOAD2=$(find apks -name '*disabled-arm64*.apk')" >> $GITHUB_ENV
           ls ./apks
 
       - name: Get Apk Info
@@ -178,6 +180,8 @@ jobs:
           VERSION_CODE: ${{steps.apk.outputs.versionCode}}
           VERSION_NAME: ${{steps.apk.outputs.versionNum}}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          APK_FILE_UPLOAD1: ${{ env.APK_FILE_UPLOAD1 }}
+          APK_FILE_UPLOAD2: ${{ env.APK_FILE_UPLOAD2 }}
 
   telegram-bot-api:
     name: Telegram Bot API

--- a/README-EN.md
+++ b/README-EN.md
@@ -15,9 +15,13 @@ Reads images selected within the app or shared from other apps, detects faces in
     alt="Get it on Obtainium"
     height="80">](http://obtainium-redirect.maary.top/?r=obtainium://add/https://github.com/Steve-Mr/EmojiFace)
 
+We offer two APK variants. Please choose the one that best fits your usage style:  
+
+- `default`: The app icon is visible by default after installation. You can hide the icon from the in-app settings, but this might not work perfectly on all Android systems.  
+- `icon-disabled`: The app icon is hidden by default after installation. This is the recommended choice if you primarily plan to use the app via the share menu from other applications. You can always unhide the icon later in the app's settings.  
+
 |![Screenshot 1](assets/README/Screenshot_20250322-151002_FaceMoji.png)|![Screenshot 2](assets/README/Screenshot_20250322-150958_FaceMoji.png)|
 |:-:|:-:|
-
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
     alt="Get it on Obtainium"
     height="80">](http://obtainium-redirect.maary.top/?r=obtainium://add/https://github.com/Steve-Mr/EmojiFace)
 
+应用提供两种 APK 版本，请根据您的使用习惯选择：  
+
+- `default`: 安装后默认显示应用图标。可以在设置中隐藏图标，但该功能在部分安卓系统上可能无法完美生效。   
+- `icon-disabled`: 安装后默认隐藏应用图标。如果主要通过其他应用的“分享”功能来使用此应用，推荐选择此版本。同时仍然可以进入应用设置取消隐藏图标。  
+
 |![alt text](assets/README/Screenshot_20250322-151002_FaceMoji.png)|![alt text](assets/README/Screenshot_20250322-150958_FaceMoji.png)|
 |:-:|:-:|
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         minSdk = 30
         targetSdk = 35
         versionCode = 2
-        versionName = "2025.06.15"
+        versionName = "2025.06.21"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,7 +67,24 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
+
+    flavorDimensions("icon")
+
+    productFlavors {
+        create("default") {
+            dimension = "icon"
+            manifestPlaceholders["mainActivityEnabled"] = "true"
+            buildConfigField("boolean", "ICON_ENABLED", "true")
+        }
+        create("icon-disabled") {
+            dimension = "icon"
+            manifestPlaceholders["mainActivityEnabled"] = "false"
+            buildConfigField("boolean", "ICON_ENABLED", "false")
+        }
+    }
+
     splits {
         // Configures multiple APKs based on ABI.
         abi {
@@ -76,9 +93,10 @@ android {
             // Resets the list of ABIs for Gradle to create APKs for to none.
             reset()
             // Specifies a list of ABIs for Gradle to create APKs for.
-            include("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
+            //noinspection ChromeOsAbiSupport
+            include("arm64-v8a")
             // Specifies that you don't want to also generate a universal APK that includes all ABIs.
-            isUniversalApk = false
+            isUniversalApk = true
         }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
             android:name=".MainActivityAlias"
             android:exported="true"
             android:label="@string/app_name"
+            android:enabled="${mainActivityEnabled}"
             android:theme="@style/Theme.EmojiFace"
             android:targetActivity=".MainActivity">
             <intent-filter>

--- a/app/src/main/java/top/maary/emojiface/datastore/PreferenceRepository.kt
+++ b/app/src/main/java/top/maary/emojiface/datastore/PreferenceRepository.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
+import top.maary.emojiface.BuildConfig
 import top.maary.emojiface.ui.edit.model.EmojiList
 import top.maary.emojiface.util.Constants.DEFAULT_FONT_MARKER
 import javax.inject.Inject
@@ -48,7 +49,7 @@ class PreferenceRepository @Inject constructor(@ApplicationContext context: Cont
     }
 
     val isIconHide: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[IS_ICON_HIDE] ?: false
+        preferences[IS_ICON_HIDE] ?: !BuildConfig.ICON_ENABLED
     }
 
     suspend fun updateIconState(state: Boolean) {

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -647,8 +647,14 @@ fun EditEmojiBottomSheetContent(
             )
         }
 
-        Row (modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            TextButton(
+                onClick = { onDismiss() }) {
+                Text(stringResource(R.string.cancel))
+            }
             TextButton(
                 onClick = { onConfirm() }) {
                 Text(stringResource(R.string.ok))
@@ -676,6 +682,25 @@ fun EditEmojiSideSheetContent(
             .padding(horizontal = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TextButton(
+                    onClick = { onDismiss() }) {
+                    Text(stringResource(R.string.cancel))
+                }
+                TextButton(
+                    onClick = { onConfirm() }) {
+                    Text(stringResource(R.string.ok))
+                }
+            }
+        }
 
         item {
             Spacer(modifier = Modifier.height(8.dp))
@@ -757,17 +782,6 @@ fun EditEmojiSideSheetContent(
                 minRange = -90f,
                 maxRange = 90f
             )
-        }
-        item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
-            ) {
-                TextButton(
-                    onClick = { onConfirm() }) {
-                    Text(stringResource(R.string.ok))
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -579,7 +579,7 @@ fun EmojiOverlay(
     editingEmoji: EmojiDetection?,
     padding: PaddingValues,
     cornerRadius: Dp,
-    ) {
+) {
     // 获取原始图片尺寸和屏幕上容器的尺寸，用于坐标和大小的缩放
     val originalWidth = state.currentImage?.width?.toFloat() ?: return
     val originalHeight = state.currentImage.height.toFloat()
@@ -595,11 +595,17 @@ fun EmojiOverlay(
     val emojisToRender = remember(state.emojiDetections, editingEmoji) {
         val list = state.emojiDetections.toMutableList()
         val editingEmoji = editingEmoji
-        val editingIndex = list.indexOfFirst { it.xCenter == editingEmoji?.xCenter && it.yCenter == editingEmoji.yCenter }.takeIf { it != -1 }
 
-        if (editingEmoji != null && editingIndex != null) {
-            // 如果正在编辑，用临时状态替换列表中的对应项
-            list[editingIndex] = editingEmoji
+        if (editingEmoji != null) {
+            val editingIndex = list.indexOfFirst { it.xCenter == editingEmoji.xCenter && it.yCenter == editingEmoji.yCenter }.takeIf { it != -1 }
+
+            if (editingIndex != null) {
+                // 原有逻辑：如果找到了（编辑模式），就替换它
+                list[editingIndex] = editingEmoji
+            } else {
+                // 新增逻辑：如果没找到（新增模式），就把它添加到列表末尾
+                list.add(editingEmoji)
+            }
         }
         list
     }
@@ -614,7 +620,7 @@ fun EmojiOverlay(
     }
 
     // 使用 Canvas Composable 进行绘制
-    Canvas(modifier = Modifier.fillMaxSize().padding(padding).clip(RoundedCornerShape(cornerRadius)).background(MaterialTheme.colorScheme.primary.copy(alpha = 0.6f))) {
+    Canvas(modifier = Modifier.fillMaxSize().padding(padding).clip(RoundedCornerShape(cornerRadius))) {
         emojisToRender.forEach { detection ->
             // 从 state 获取加载好的原生 Typeface
             paint.typeface = state.typeface ?: Typeface.DEFAULT

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -1,5 +1,8 @@
 package top.maary.emojiface.ui.components
 
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -7,6 +10,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -69,6 +73,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.stringResource
@@ -80,6 +86,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.times
 import kotlinx.coroutines.launch
 import top.maary.emojiface.R
+import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
 import top.maary.emojiface.util.Constants.DEFAULT_FONT_MARKER
@@ -567,57 +574,151 @@ fun EditEmojiBottomSheetContent(
 }
 
 @Composable
-fun DisplayPane(modifier: Modifier, state: EditScreenState, actions: EditScreenActions) {
+fun EmojiOverlay(
+    state: EditScreenState,
+    editingEmoji: EmojiDetection?,
+    padding: PaddingValues,
+    cornerRadius: Dp,
+    ) {
+    // 获取原始图片尺寸和屏幕上容器的尺寸，用于坐标和大小的缩放
+    val originalWidth = state.currentImage?.width?.toFloat() ?: return
+    val originalHeight = state.currentImage.height.toFloat()
+    val containerWidth = state.imageContainerSize.width.toFloat()
+    val containerHeight = state.imageContainerSize.height.toFloat()
+
+    if (containerWidth == 0f || containerHeight == 0f) return
+
+    // 计算缩放比例
+    val scale = containerWidth / originalWidth
+
+    // 合并固定列表和正在编辑的临时状态，用于统一渲染
+    val emojisToRender = remember(state.emojiDetections, editingEmoji) {
+        val list = state.emojiDetections.toMutableList()
+        val editingEmoji = editingEmoji
+        val editingIndex = list.indexOfFirst { it.xCenter == editingEmoji?.xCenter && it.yCenter == editingEmoji.yCenter }.takeIf { it != -1 }
+
+        if (editingEmoji != null && editingIndex != null) {
+            // 如果正在编辑，用临时状态替换列表中的对应项
+            list[editingIndex] = editingEmoji
+        }
+        list
+    }
+
+    // 创建一个可以在重组间复用的 Paint 对象
+    val paint = remember {
+        Paint().apply {
+            isAntiAlias = true
+            color = android.graphics.Color.BLACK
+            textAlign = Paint.Align.CENTER
+        }
+    }
+
+    // 使用 Canvas Composable 进行绘制
+    Canvas(modifier = Modifier.fillMaxSize().padding(padding).clip(RoundedCornerShape(cornerRadius)).background(MaterialTheme.colorScheme.primary.copy(alpha = 0.6f))) {
+        emojisToRender.forEach { detection ->
+            // 从 state 获取加载好的原生 Typeface
+            paint.typeface = state.typeface ?: Typeface.DEFAULT
+
+            // 实时计算缩放后的大小
+            paint.textSize = detection.diameter * scale
+
+            // 计算垂直方向的偏移，与 RenderEmojiOnBitmapUseCase 完全一致
+            val verticalOffset = (paint.descent() + paint.ascent()) / 2
+
+            // 缩放坐标
+            val centerX = detection.xCenter * scale
+            val centerY = detection.yCenter * scale
+
+            // 将所有绘制操作放在 rotate 的 lambda 块中
+            // Compose 会自动处理 save 和 restore
+            rotate(
+                degrees = detection.angle,
+                pivot = Offset(centerX, centerY)
+            ) {
+                // 在这个代码块中执行的所有绘制操作都会被旋转
+                drawContext.canvas.nativeCanvas.drawText(
+                    detection.emoji,
+                    centerX,
+                    centerY - verticalOffset,
+                    paint
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun DisplayPane(modifier: Modifier, state: EditScreenState, actions: EditScreenActions, editingEmoji: EmojiDetection?) {
     // --- 圖片顯示區域 ---
     Box(
         modifier = modifier,
         contentAlignment = Alignment.Center
     ) {
         if (state.displayedBitmap != null) {
-            // 顯示處理結果或原圖
-            ResultImg(
-                modifier = Modifier
-                    .aspectRatio(state.aspectRatio ?: 1f) // 使用 state 中的寬高比
-                    .fillMaxSize()
-                    .onGloballyPositioned { layoutCoordinates ->
-                        // 回報容器尺寸
-                        actions.onImageContainerMeasured(layoutCoordinates.size)
-                    }
-                    .then( // 根據 isAddMode 條件性添加 pointerInput
-                        if (state.isAddMode) {
-                            Modifier.pointerInput(Unit) { // key=Unit 表示不依賴特定狀態重啟協程
-                                detectTapGestures { offset ->
-                                    // 將點擊的 UI 座標轉換為原始圖片座標
-                                    val containerWidth = state.imageContainerSize.width
-                                    val containerHeight = state.imageContainerSize.height
-                                    // 使用 currentImage (原始 Bitmap) 的尺寸來計算比例
-                                    val originalBitmapWidth =
-                                        state.currentImage?.width ?: state.displayedBitmap.width
-                                    val originalBitmapHeight =
-                                        state.currentImage?.height ?: state.displayedBitmap.height
 
-                                    if (containerWidth > 0 && containerHeight > 0) {
-                                        val scaleX = originalBitmapWidth.toFloat() / containerWidth
-                                        val scaleY =
-                                            originalBitmapHeight.toFloat() / containerHeight
-                                        val originalX = offset.x * scaleX
-                                        val originalY = offset.y * scaleY
-                                        // 傳遞轉換後的座標
-                                        actions.onImageTapToAdd(Offset(originalX, originalY))
-                                    } else {
-                                        // 如果容器尺寸為0，作為備用方案傳遞原始 offset
-                                        // 或者可以選擇不觸發 action / 顯示錯誤
-                                        actions.onImageTapToAdd(offset)
-                                    }
+            val cornerRadius = 16.dp
+            val verticalPadding = 8.dp
+            // 水平 padding 依赖于宽高比，与 ResultImg 内部逻辑保持一致
+            val horizontalPadding = (state.aspectRatio ?: 1f) * 8f.dp
+
+            // 准备一个用于覆盖层的 Box，它的大小将和图片容器一致
+            Box(
+                modifier = Modifier
+                    .aspectRatio(state.aspectRatio ?: 1f)
+                    .fillMaxSize()
+            ) {
+                GlowingCard (
+                    modifier = Modifier
+                        .aspectRatio(state.aspectRatio ?: 1f) // 使用 state 中的寬高比
+                        .fillMaxSize(),
+                    ratio = state.aspectRatio ?: 1f,
+                    animate = state.isProcessing,
+                    cornersRadius = 16.dp,
+                    content = {
+                        Image(bitmap = state.displayedBitmap,
+                            contentDescription = stringResource(R.string.process_result),
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = (state.aspectRatio ?: 1f) * 8.dp, vertical = 8.dp)
+                                .clip(
+                                    RoundedCornerShape(16.dp)
+                                ).onGloballyPositioned { layoutCoordinates ->
+                                    // 回報容器尺寸
+                                    actions.onImageContainerMeasured(layoutCoordinates.size)
                                 }
-                            }
-                        } else Modifier // 非 AddMode 時不添加 pointerInput
-                    ),
-                bitmap = state.displayedBitmap, // 使用 state 中的 bitmap
-                description = stringResource(R.string.process_result),
-                animate = state.isProcessing, // 使用 state 控制動畫
-                ratio = state.aspectRatio ?: 1f // 傳遞寬高比給 GlowingCard
-            )
+                                .then( if (state.isAddMode) {
+                                    Modifier.pointerInput(Unit) { // 合并 pointerInput
+
+                                        detectTapGestures { offset ->
+                                            // ... (原有的 onImageTapToAdd 逻辑保持不变)
+                                            val containerWidth = state.imageContainerSize.width
+                                            val containerHeight = state.imageContainerSize.height
+                                            val originalBitmapWidth = state.currentImage?.width ?: state.displayedBitmap.width
+                                            val originalBitmapHeight = state.currentImage?.height ?: state.displayedBitmap.height
+
+                                            if (containerWidth > 0 && containerHeight > 0) {
+                                                val scaleX = originalBitmapWidth.toFloat() / containerWidth
+                                                val scaleY = originalBitmapHeight.toFloat() / containerHeight
+                                                val originalX = offset.x * scaleX
+                                                val originalY = offset.y * scaleY
+                                                actions.onImageTapToAdd(Offset(originalX, originalY))
+                                            } else {
+                                                actions.onImageTapToAdd(offset)
+                                            }
+                                        }
+
+                                    }
+                                } else Modifier
+                                ))
+                    }
+                )
+
+                EmojiOverlay(state = state, editingEmoji = editingEmoji,
+                    padding = PaddingValues(horizontal = horizontalPadding, vertical = verticalPadding),
+                    cornerRadius = cornerRadius,)
+
+            }
+
         } else {
             // 沒有圖片時顯示選擇圖片按鈕
             ExtendedFloatingActionButton(

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -59,7 +59,6 @@ import androidx.compose.material3.rememberTooltipState
 import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -487,12 +486,10 @@ fun EditEmojiBottomSheetContent(
     maxDiameter: Float,
     availableEmojis: List<String>,
     fontFamily: FontFamily?,
-    onConfirm: (String, Float, Float) -> Unit,
+    onValueChange: (emoji: String?, diameter: Float?, rotation: Float?) -> Unit,
+    onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ){
-    var newEmoji by remember { mutableStateOf(initialEmoji) }
-    var newDiameter by remember { mutableFloatStateOf(initialDiameter) }
-    var newRotation by remember { mutableFloatStateOf(initialRotation) }
 
     Column (modifier = Modifier
         .fillMaxWidth()
@@ -504,8 +501,8 @@ fun EditEmojiBottomSheetContent(
         Row (verticalAlignment = Alignment.CenterVertically) {
             OutlinedTextField(
                 modifier = Modifier.width(96.dp),
-                value = newEmoji,
-                onValueChange = { newEmoji = it },
+                value = initialEmoji,
+                onValueChange = { onValueChange(it, null, null) },
                 label = { Text(stringResource(R.string.new_emoji))},
                 textStyle = TextStyle(fontFamily = fontFamily, fontSize = 20.sp)
             )
@@ -516,7 +513,7 @@ fun EditEmojiBottomSheetContent(
                     Spacer(modifier = Modifier.width(8.dp))
                 }
                 itemsIndexed(availableEmojis) { _, emoji ->
-                    EmojiCardSmall(emoji = emoji, onClick = { newEmoji = emoji }, fontFamily = fontFamily)
+                    EmojiCardSmall(emoji = emoji, onClick = { onValueChange(emoji, null, null) }, fontFamily = fontFamily)
                 }
             }
         }
@@ -534,8 +531,8 @@ fun EditEmojiBottomSheetContent(
                             .size(16.dp))
                 },
                 description = stringResource(R.string.emoji_size),
-                value = newDiameter,
-                onValueChange = { newDiameter = it },
+                value = initialDiameter,
+                onValueChange = { onValueChange(null, it, null) },
                 minRange = 20f,
                 maxRange = maxDiameter
             )
@@ -552,8 +549,8 @@ fun EditEmojiBottomSheetContent(
                             .size(16.dp))
                 },
                 description = stringResource(R.string.emoji_angle),
-                value = newRotation,
-                onValueChange = { newRotation = it },
+                value = initialRotation,
+                onValueChange = { onValueChange(null, null, it) },
                 minRange = -90f,
                 maxRange = 90f
             )
@@ -562,7 +559,7 @@ fun EditEmojiBottomSheetContent(
         Row (modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.End) {
             TextButton(
-                onClick = { onConfirm(newEmoji, newDiameter, newRotation) }) {
+                onClick = { onConfirm() }) {
                 Text(stringResource(R.string.ok))
             }
         }

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.icons.outlined.RemoveCircleOutline
 import androidx.compose.material.icons.outlined.Rotate90DegreesCw
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.rounded.SaveAlt
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenuItem
@@ -149,7 +148,9 @@ fun EmojiCard(emoji: String,
             .background(containerColor)
             .clickable(enabled = clickable) { onClick() },  // 添加点击事件
     ) {
-        Text(text = emoji, fontSize = 40.sp, fontFamily = fontFamily, modifier = Modifier.padding(8.dp).align(Alignment.Center))
+        Text(text = emoji, fontSize = 40.sp, fontFamily = fontFamily, modifier = Modifier
+            .padding(8.dp)
+            .align(Alignment.Center))
     }
 }
 
@@ -181,9 +182,12 @@ fun ResultImg(modifier: Modifier, bitmap: ImageBitmap, description: String, rati
         content = {
             Image(bitmap = bitmap,
                 contentDescription = description,
-                modifier = Modifier.fillMaxSize().padding(horizontal = ratio*8.dp, vertical = 8.dp).clip(
-                    RoundedCornerShape(16.dp)
-                ))
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = ratio * 8.dp, vertical = 8.dp)
+                    .clip(
+                        RoundedCornerShape(16.dp)
+                    ))
         }
     )
 }
@@ -195,7 +199,9 @@ fun PredefinedEmojiSettings(
     fontFamily: FontFamily? = null
 ) {
     LazyRow(modifier = Modifier.padding(vertical = 8.dp)) {
-        item { Spacer(modifier = Modifier.height(8.dp).width(16.dp)) }
+        item { Spacer(modifier = Modifier
+            .height(8.dp)
+            .width(16.dp)) }
         itemsIndexed(emojiOptions) { _, emoji ->
             EmojiCardSmall(emoji = emoji, onClick = onClick, fontFamily = fontFamily)
         }
@@ -207,7 +213,9 @@ fun PredefinedEmojiSettings(
 fun EditEmojiList(emojiOptions: List<String>, onClick: (String) -> Unit, fontFamily: FontFamily? = null) {
     var text by remember { mutableStateOf(emojiOptions.joinToString(separator = "")) }
     OutlinedTextField(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
         value = text,
         trailingIcon = {
             IconButton(onClick = { onClick(text) }) {
@@ -226,7 +234,8 @@ fun HomeSwitchRow(
 ) {
     Row(
         modifier = Modifier
-            .fillMaxWidth().clickable { onCheckedChange(!state) }
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!state) }
             .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
@@ -365,95 +374,31 @@ fun DropdownRow(
 
 @Composable
 fun SliderWithCaption(
+    modifier: Modifier = Modifier,
     leadingIcon: @Composable (() -> Unit),
     description: String,
     value: Float,
     onValueChange: (Float) -> Unit,
     minRange: Float,
-    maxRange: Float) {
-    Row (modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically){
-        leadingIcon()
-        Column {
-            Text(text = description, modifier = Modifier.padding(start = 8.dp))
-            Slider(
-                modifier = Modifier.padding(horizontal = 8.dp),
-                value = value,
-                onValueChange = onValueChange,
-                valueRange = minRange..maxRange
-            )
-        }
-    }
-}
+    maxRange: Float
+) {
 
-@Composable
-fun EditEmojiDialog(
-    initialEmoji: String,
-    initialDiameter: Float,
-    initialRotation: Float,
-    maxDiameter: Float,
-    availableEmojis: List<String>,
-    fontFamily: FontFamily?,
-    onConfirm: (String, Float, Float) -> Unit,
-    onDismiss: () -> Unit
-){
-    var newEmoji by remember { mutableStateOf(initialEmoji) }
-    var newDiameter by remember { mutableFloatStateOf(initialDiameter) }
-    var newRotation by remember { mutableFloatStateOf(initialRotation) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.change_emoji)) },
-        text = {
-            Column {
-                OutlinedTextField(
-                    value = newEmoji,
-                    onValueChange = { newEmoji = it },
-                    label = { Text(stringResource(R.string.new_emoji))},
-                    textStyle = TextStyle(fontFamily = fontFamily, fontSize = 20.sp)
-                )
-                // 预置 emoji 选择行
-                LazyRow(modifier = Modifier.padding(vertical = 8.dp)) {
-                    itemsIndexed(availableEmojis) { _, emoji ->
-                        EmojiCardSmall(emoji = emoji, onClick = { newEmoji = emoji }, fontFamily = fontFamily)
-                    }
-                }
-                SliderWithCaption(
-                    leadingIcon = {
-                        Icon(imageVector = Icons.Outlined.FormatSize,
-                            contentDescription = stringResource(R.string.emoji_size),
-                            modifier = Modifier.padding(8.dp).size(24.dp))
-                    },
-                    description = stringResource(R.string.emoji_size),
-                    value = newDiameter,
-                    onValueChange = { newDiameter = it },
-                    minRange = 20f,
-                    maxRange = maxDiameter
-                )
-                SliderWithCaption(
-                    leadingIcon = {
-                        Icon(imageVector = Icons.Outlined.Rotate90DegreesCw,
-                            contentDescription = stringResource(R.string.emoji_angle),
-                            modifier = Modifier.padding(8.dp).size(24.dp))
-                    },
-                    description = stringResource(R.string.emoji_angle),
-                    value = newRotation,
-                    onValueChange = { newRotation = it },
-                    minRange = -90f,
-                    maxRange = 90f
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(newEmoji, newDiameter, newRotation) }) {
-                Text(stringResource(R.string.ok))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.cancel))
-            }
+    Column(
+        modifier = modifier.clip(RoundedCornerShape(12.dp)).background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            leadingIcon()
+            Text(text = description, fontSize = 14.sp)
         }
-    )
+
+        Slider(
+            modifier = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = minRange..maxRange
+        )
+
+    }
 }
 
 @Composable
@@ -471,8 +416,16 @@ fun SettingsBottomSheetContent(
     onAddFontClick: () -> Unit,
     onRemoveFontClick: (index: Int) -> Unit,
 ) {
-    Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
-        .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp, bottomStart = 4.dp, bottomEnd = 4.dp))
+    Box(modifier = Modifier
+        .padding(horizontal = 8.dp, vertical = 2.dp)
+        .clip(
+            RoundedCornerShape(
+                topStart = 24.dp,
+                topEnd = 24.dp,
+                bottomStart = 4.dp,
+                bottomEnd = 4.dp
+            )
+        )
         .background(MaterialTheme.colorScheme.surfaceContainerLow)){
         Column {
             Text(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 0.dp),
@@ -490,15 +443,31 @@ fun SettingsBottomSheetContent(
             }
         }
     }
-    Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
-        .clip(RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bottomStart = 4.dp, bottomEnd = 4.dp))
+    Box(modifier = Modifier
+        .padding(horizontal = 8.dp, vertical = 2.dp)
+        .clip(
+            RoundedCornerShape(
+                topStart = 4.dp,
+                topEnd = 4.dp,
+                bottomStart = 4.dp,
+                bottomEnd = 4.dp
+            )
+        )
         .background(MaterialTheme.colorScheme.surfaceContainerLow)){
         HomeSwitchRow(state = isAppIconHidden, onCheckedChange = { onHideIconToggle(it) })
 
     }
 
-    Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
-        .clip(RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bottomStart = 24.dp, bottomEnd = 24.dp))
+    Box(modifier = Modifier
+        .padding(horizontal = 8.dp, vertical = 2.dp)
+        .clip(
+            RoundedCornerShape(
+                topStart = 4.dp,
+                topEnd = 4.dp,
+                bottomStart = 24.dp,
+                bottomEnd = 24.dp
+            )
+        )
         .background(MaterialTheme.colorScheme.surfaceContainerLow)){
         DropdownRow(
             options = availableFontNames.toMutableList(),
@@ -508,6 +477,96 @@ fun SettingsBottomSheetContent(
             onRemoveClick = { onRemoveFontClick(it) })
     }
 
+}
+
+@Composable
+fun EditEmojiBottomSheetContent(
+    initialEmoji: String,
+    initialDiameter: Float,
+    initialRotation: Float,
+    maxDiameter: Float,
+    availableEmojis: List<String>,
+    fontFamily: FontFamily?,
+    onConfirm: (String, Float, Float) -> Unit,
+    onDismiss: () -> Unit
+){
+    var newEmoji by remember { mutableStateOf(initialEmoji) }
+    var newDiameter by remember { mutableFloatStateOf(initialDiameter) }
+    var newRotation by remember { mutableFloatStateOf(initialRotation) }
+
+    Column (modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally) {
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Row (verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                modifier = Modifier.width(96.dp),
+                value = newEmoji,
+                onValueChange = { newEmoji = it },
+                label = { Text(stringResource(R.string.new_emoji))},
+                textStyle = TextStyle(fontFamily = fontFamily, fontSize = 20.sp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            // 预置 emoji 选择行
+            LazyRow(modifier = Modifier.clip(RoundedCornerShape(12.dp)).background(MaterialTheme.colorScheme.surfaceContainerHigh).padding(vertical = 8.dp)) {
+                item {
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                itemsIndexed(availableEmojis) { _, emoji ->
+                    EmojiCardSmall(emoji = emoji, onClick = { newEmoji = emoji }, fontFamily = fontFamily)
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(modifier = Modifier.fillMaxWidth()) {
+            SliderWithCaption(
+                modifier = Modifier.weight(1f),
+                leadingIcon = {
+                    Icon(imageVector = Icons.Outlined.FormatSize,
+                        contentDescription = stringResource(R.string.emoji_size),
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .size(16.dp))
+                },
+                description = stringResource(R.string.emoji_size),
+                value = newDiameter,
+                onValueChange = { newDiameter = it },
+                minRange = 20f,
+                maxRange = maxDiameter
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            SliderWithCaption(
+                modifier = Modifier.weight(1f),
+                leadingIcon = {
+                    Icon(imageVector = Icons.Outlined.Rotate90DegreesCw,
+                        contentDescription = stringResource(R.string.emoji_angle),
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .size(16.dp))
+                },
+                description = stringResource(R.string.emoji_angle),
+                value = newRotation,
+                onValueChange = { newRotation = it },
+                minRange = -90f,
+                maxRange = 90f
+            )
+        }
+
+        Row (modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End) {
+            TextButton(
+                onClick = { onConfirm(newEmoji, newDiameter, newRotation) }) {
+                Text(stringResource(R.string.ok))
+            }
+        }
+    }
 }
 
 @Composable
@@ -535,12 +594,15 @@ fun DisplayPane(modifier: Modifier, state: EditScreenState, actions: EditScreenA
                                     val containerWidth = state.imageContainerSize.width
                                     val containerHeight = state.imageContainerSize.height
                                     // 使用 currentImage (原始 Bitmap) 的尺寸來計算比例
-                                    val originalBitmapWidth = state.currentImage?.width ?: state.displayedBitmap.width
-                                    val originalBitmapHeight = state.currentImage?.height ?: state.displayedBitmap.height
+                                    val originalBitmapWidth =
+                                        state.currentImage?.width ?: state.displayedBitmap.width
+                                    val originalBitmapHeight =
+                                        state.currentImage?.height ?: state.displayedBitmap.height
 
                                     if (containerWidth > 0 && containerHeight > 0) {
                                         val scaleX = originalBitmapWidth.toFloat() / containerWidth
-                                        val scaleY = originalBitmapHeight.toFloat() / containerHeight
+                                        val scaleY =
+                                            originalBitmapHeight.toFloat() / containerHeight
                                         val originalX = offset.x * scaleX
                                         val originalY = offset.y * scaleY
                                         // 傳遞轉換後的座標

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -390,7 +391,9 @@ fun SliderWithCaption(
 ) {
 
     Column(
-        modifier = modifier.clip(RoundedCornerShape(12.dp)).background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         horizontalAlignment = Alignment.CenterHorizontally) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             leadingIcon()
@@ -409,6 +412,84 @@ fun SliderWithCaption(
 
 @Composable
 fun SettingsBottomSheetContent(
+    emojiOptions: List<String>,
+    isEditingEmojiList: Boolean,
+    fontFamily: FontFamily?,
+    isAppIconHidden: Boolean,
+    availableFontNames: List<String>,
+    selectedFontIndex: Int,
+    onEditClick: () -> Unit,
+    onEditConfirm: (newEmojiListString: String) -> Unit,
+    onHideIconToggle: (hide: Boolean) -> Unit,
+    onFontSelected: (index: Int) -> Unit,
+    onAddFontClick: () -> Unit,
+    onRemoveFontClick: (index: Int) -> Unit,
+) {
+    Box(modifier = Modifier
+        .padding(horizontal = 8.dp, vertical = 2.dp)
+        .clip(
+            RoundedCornerShape(
+                topStart = 24.dp,
+                topEnd = 24.dp,
+                bottomStart = 4.dp,
+                bottomEnd = 4.dp
+            )
+        )
+        .background(MaterialTheme.colorScheme.surfaceContainerLow)){
+        Column {
+            Text(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 0.dp),
+                text = stringResource(R.string.emoji_list))
+            if (!isEditingEmojiList) {
+                PredefinedEmojiSettings(
+                    emojiOptions = emojiOptions,
+                    onClick = onEditClick,
+                    fontFamily = fontFamily)
+            } else {
+                EditEmojiList(
+                    emojiOptions = emojiOptions,
+                    onClick = onEditConfirm,
+                    fontFamily = fontFamily)
+            }
+        }
+    }
+    Box(modifier = Modifier
+        .padding(horizontal = 8.dp, vertical = 2.dp)
+        .clip(
+            RoundedCornerShape(
+                topStart = 4.dp,
+                topEnd = 4.dp,
+                bottomStart = 4.dp,
+                bottomEnd = 4.dp
+            )
+        )
+        .background(MaterialTheme.colorScheme.surfaceContainerLow)){
+        HomeSwitchRow(state = isAppIconHidden, onCheckedChange = { onHideIconToggle(it) })
+
+    }
+
+    Box(modifier = Modifier
+        .padding(horizontal = 8.dp, vertical = 2.dp)
+        .clip(
+            RoundedCornerShape(
+                topStart = 4.dp,
+                topEnd = 4.dp,
+                bottomStart = 24.dp,
+                bottomEnd = 24.dp
+            )
+        )
+        .background(MaterialTheme.colorScheme.surfaceContainerLow)){
+        DropdownRow(
+            options = availableFontNames.toMutableList(),
+            position = selectedFontIndex,
+            onItemClicked = onFontSelected,
+            onAddClick = onAddFontClick,
+            onRemoveClick = { onRemoveFontClick(it) })
+    }
+
+}
+
+@Composable
+fun SettingsSideSheetContent(
     emojiOptions: List<String>,
     isEditingEmojiList: Boolean,
     fontFamily: FontFamily?,
@@ -515,7 +596,10 @@ fun EditEmojiBottomSheetContent(
             )
             Spacer(modifier = Modifier.width(8.dp))
             // 预置 emoji 选择行
-            LazyRow(modifier = Modifier.clip(RoundedCornerShape(12.dp)).background(MaterialTheme.colorScheme.surfaceContainerHigh).padding(vertical = 8.dp)) {
+            LazyRow(modifier = Modifier
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .padding(vertical = 8.dp)) {
                 item {
                     Spacer(modifier = Modifier.width(8.dp))
                 }
@@ -574,6 +658,121 @@ fun EditEmojiBottomSheetContent(
 }
 
 @Composable
+fun EditEmojiSideSheetContent(
+    initialEmoji: String,
+    initialDiameter: Float,
+    initialRotation: Float,
+    maxDiameter: Float,
+    availableEmojis: List<String>,
+    fontFamily: FontFamily?,
+    onValueChange: (emoji: String?, diameter: Float?, rotation: Float?) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        item {
+            OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = initialEmoji,
+            onValueChange = { onValueChange(it, null, null) },
+            label = { Text(stringResource(R.string.new_emoji)) },
+            textStyle = TextStyle(fontFamily = fontFamily, fontSize = 20.sp)
+        ) }
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+
+        }
+
+        item {
+            // 预置 emoji 选择行
+            LazyRow(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .padding(vertical = 8.dp)
+            ) {
+                item {
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                itemsIndexed(availableEmojis) { _, emoji ->
+                    EmojiCardSmall(
+                        emoji = emoji,
+                        onClick = { onValueChange(emoji, null, null) },
+                        fontFamily = fontFamily
+                    )
+                }
+            }
+        }
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+        item {
+            SliderWithCaption(
+                modifier = Modifier.fillMaxWidth(),
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.FormatSize,
+                        contentDescription = stringResource(R.string.emoji_size),
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .size(16.dp)
+                    )
+                },
+                description = stringResource(R.string.emoji_size),
+                value = initialDiameter,
+                onValueChange = { onValueChange(null, it, null) },
+                minRange = 20f,
+                maxRange = maxDiameter
+            )
+        }
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+        item {
+            SliderWithCaption(
+                modifier = Modifier.fillMaxWidth(),
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Rotate90DegreesCw,
+                        contentDescription = stringResource(R.string.emoji_angle),
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .size(16.dp)
+                    )
+                },
+                description = stringResource(R.string.emoji_angle),
+                value = initialRotation,
+                onValueChange = { onValueChange(null, null, it) },
+                minRange = -90f,
+                maxRange = 90f
+            )
+        }
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(
+                    onClick = { onConfirm() }) {
+                    Text(stringResource(R.string.ok))
+                }
+            }
+        }
+    }
+}
+
+@Composable
 fun EmojiOverlay(
     state: EditScreenState,
     editingEmoji: EmojiDetection?,
@@ -620,7 +819,10 @@ fun EmojiOverlay(
     }
 
     // 使用 Canvas Composable 进行绘制
-    Canvas(modifier = Modifier.fillMaxSize().padding(padding).clip(RoundedCornerShape(cornerRadius))) {
+    Canvas(modifier = Modifier
+        .fillMaxSize()
+        .padding(padding)
+        .clip(RoundedCornerShape(cornerRadius))) {
         emojisToRender.forEach { detection ->
             // 从 state 获取加载好的原生 Typeface
             paint.typeface = state.typeface ?: Typeface.DEFAULT
@@ -685,29 +887,43 @@ fun DisplayPane(modifier: Modifier, state: EditScreenState, actions: EditScreenA
                             contentDescription = stringResource(R.string.process_result),
                             modifier = Modifier
                                 .fillMaxSize()
-                                .padding(horizontal = (state.aspectRatio ?: 1f) * 8.dp, vertical = 8.dp)
+                                .padding(
+                                    horizontal = (state.aspectRatio ?: 1f) * 8.dp,
+                                    vertical = 8.dp
+                                )
                                 .clip(
                                     RoundedCornerShape(16.dp)
-                                ).onGloballyPositioned { layoutCoordinates ->
+                                )
+                                .onGloballyPositioned { layoutCoordinates ->
                                     // 回報容器尺寸
                                     actions.onImageContainerMeasured(layoutCoordinates.size)
                                 }
-                                .then( if (state.isAddMode) {
+                                .then(
+                                    if (state.isAddMode) {
                                     Modifier.pointerInput(Unit) { // 合并 pointerInput
 
                                         detectTapGestures { offset ->
                                             // ... (原有的 onImageTapToAdd 逻辑保持不变)
                                             val containerWidth = state.imageContainerSize.width
                                             val containerHeight = state.imageContainerSize.height
-                                            val originalBitmapWidth = state.currentImage?.width ?: state.displayedBitmap.width
-                                            val originalBitmapHeight = state.currentImage?.height ?: state.displayedBitmap.height
+                                            val originalBitmapWidth = state.currentImage?.width
+                                                ?: state.displayedBitmap.width
+                                            val originalBitmapHeight = state.currentImage?.height
+                                                ?: state.displayedBitmap.height
 
                                             if (containerWidth > 0 && containerHeight > 0) {
-                                                val scaleX = originalBitmapWidth.toFloat() / containerWidth
-                                                val scaleY = originalBitmapHeight.toFloat() / containerHeight
+                                                val scaleX =
+                                                    originalBitmapWidth.toFloat() / containerWidth
+                                                val scaleY =
+                                                    originalBitmapHeight.toFloat() / containerHeight
                                                 val originalX = offset.x * scaleX
                                                 val originalY = offset.y * scaleY
-                                                actions.onImageTapToAdd(Offset(originalX, originalY))
+                                                actions.onImageTapToAdd(
+                                                    Offset(
+                                                        originalX,
+                                                        originalY
+                                                    )
+                                                )
                                             } else {
                                                 actions.onImageTapToAdd(offset)
                                             }

--- a/app/src/main/java/top/maary/emojiface/ui/components/SideSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/SideSheet.kt
@@ -1,0 +1,120 @@
+package top.maary.emojiface.ui.components
+
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+import top.maary.emojiface.ui.edit.model.EmojiDetection
+import top.maary.emojiface.ui.edit.state.EditScreenActions
+import top.maary.emojiface.ui.edit.state.EditScreenState
+
+/**
+ * 一个通用的 SideSheet 容器，封装了打开/关闭状态管理和内容显示。
+ *
+ * @param showSheet 是否请求显示 SideSheet。
+ * @param onDismissSheet 当 SideSheet 关闭时的回调。
+ * @param sheetContent SideSheet 中要显示的内容。
+ * @param content 主屏幕内容。
+ */
+@Composable
+fun SideSheet(
+    showSheet: Boolean,
+    onDismissSheet: () -> Unit,
+    sheetContent: @Composable () -> Unit,
+    content: @Composable () -> Unit
+) {
+    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+
+    // 同步外部请求状态与抽屉的打开/关闭状态
+    LaunchedEffect(showSheet) {
+        if (showSheet) {
+            drawerState.open()
+        } else {
+            drawerState.close()
+        }
+    }
+
+    // 监听抽屉的物理关闭事件（手势、点击外部），并触发回调
+    LaunchedEffect(drawerState.currentValue) {
+        if (drawerState.currentValue == DrawerValue.Closed && showSheet) {
+            onDismissSheet()
+        }
+    }
+
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            gesturesEnabled = showSheet,
+            drawerContent = {
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    ModalDrawerSheet(
+                        drawerContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+                    ) {
+                        // 直接渲染传入的 sheetContent
+                        sheetContent()
+                    }
+                }
+            }
+        ) {
+            // 恢复主内容的布局方向
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+fun SideSheetContent(
+    state: EditScreenState,
+    actions: EditScreenActions,
+    editingEmoji: EmojiDetection?,
+    showSettingsSheet: Boolean
+) {
+    val scrollState = rememberScrollState()
+        if (editingEmoji != null) {
+            val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
+            EditEmojiSideSheetContent(
+                initialEmoji = editingEmoji.emoji,
+                initialDiameter = editingEmoji.diameter,
+                initialRotation = editingEmoji.angle,
+                availableEmojis = state.predefinedEmojiList ?: emptyList(),
+                fontFamily = state.fontFamily,
+                onConfirm = actions.onConfirmEditing,
+                onDismiss = actions.onCancelEditing,
+                maxDiameter = maxDiameter,
+                onValueChange = actions.onEditingValueChanged
+            )
+        } else if (showSettingsSheet) {
+            var isEditingEmojiListInSheet by remember { mutableStateOf(false) }
+            SettingsSideSheetContent(
+                emojiOptions = state.predefinedEmojiList ?: emptyList(),
+                isEditingEmojiList = isEditingEmojiListInSheet,
+                fontFamily = state.fontFamily,
+                isAppIconHidden = state.isAppIconHidden,
+                availableFontNames = state.availableFontNames ?: emptyList(),
+                selectedFontIndex = state.selectedFontIndex,
+                onEditClick = { isEditingEmojiListInSheet = true },
+                onEditConfirm = { newEmojiList ->
+                    actions.onPredefinedEmojisEdited(newEmojiList)
+                    isEditingEmojiListInSheet = false
+                },
+                onHideIconToggle = actions.onHideIconToggle,
+                onFontSelected = actions.onFontSelected,
+                onAddFontClick = actions.onAddFontClick,
+                onRemoveFontClick = actions.onRemoveFontClick
+            )
+        }
+
+}

--- a/app/src/main/java/top/maary/emojiface/ui/components/SideSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/SideSheet.kt
@@ -31,6 +31,7 @@ import top.maary.emojiface.ui.edit.state.EditScreenState
 fun SideSheet(
     showSheet: Boolean,
     onDismissSheet: () -> Unit,
+    isModal: Boolean = true,
     sheetContent: @Composable () -> Unit,
     content: @Composable () -> Unit
 ) {
@@ -47,7 +48,7 @@ fun SideSheet(
 
     // 监听抽屉的物理关闭事件（手势、点击外部），并触发回调
     LaunchedEffect(drawerState.currentValue) {
-        if (drawerState.currentValue == DrawerValue.Closed && showSheet) {
+        if (isModal && drawerState.currentValue == DrawerValue.Closed && showSheet) {
             onDismissSheet()
         }
     }
@@ -55,7 +56,7 @@ fun SideSheet(
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
         ModalNavigationDrawer(
             drawerState = drawerState,
-            gesturesEnabled = showSheet,
+            gesturesEnabled = isModal && showSheet,
             drawerContent = {
                 CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
                     ModalDrawerSheet(

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -151,8 +151,8 @@ fun EditScreenContentInternal(
 
     // --- 5. Derive UI-Specific Values from uiState ---
     // Use remember to avoid recalculating on every recomposition unless inputs change
-    val displayedBitmapForUi = remember(uiState.processedBitmap, uiState.originalBitmap) {
-        (uiState.processedBitmap ?: uiState.originalBitmap)?.asImageBitmap()
+    val displayedBitmapForUi = remember(uiState.originalBitmap) {
+        uiState.originalBitmap?.asImageBitmap()
     }
     val currentImageForUi = remember(uiState.originalBitmap) { // Needed? Only if layout explicitly needs original
         uiState.originalBitmap?.asImageBitmap()
@@ -175,7 +175,7 @@ fun EditScreenContentInternal(
     }
     // Combine ViewModel's processing state with UI's add mode for animation trigger
     val isProcessingForAnimation = remember(uiState.isProcessing, uiState.isRendering, isAddMode) {
-        derivedStateOf { uiState.isProcessing || isAddMode }
+        derivedStateOf { uiState.isProcessing || uiState.isRendering || isAddMode }
     }.value
 
 
@@ -195,7 +195,8 @@ fun EditScreenContentInternal(
         availableFontNames = fontNames, // Derived value
         selectedFontIndex = selectedFontIndex, // Derived value
         isMediumLayout = isMediumLayout, // Pass local state if needed by ActionRow etc.
-        typeface = uiState.loadedTypeface // Direct from uiState
+        typeface = uiState.loadedTypeface, // Direct from uiState
+        editingEmojiIndex = uiState.editingEmoji?.let { uiState.selectedEmojis.indexOf(it) } // Get index of currently editing emoji
     )
 
     // --- 7. Create EditScreenActions Instance (Largely unchanged) ---

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -194,7 +194,8 @@ fun EditScreenContentInternal(
         isAppIconHidden = uiState.isAppIconHidden, // Direct from uiState
         availableFontNames = fontNames, // Derived value
         selectedFontIndex = selectedFontIndex, // Derived value
-        isMediumLayout = isMediumLayout // Pass local state if needed by ActionRow etc.
+        isMediumLayout = isMediumLayout, // Pass local state if needed by ActionRow etc.
+        typeface = uiState.loadedTypeface // Direct from uiState
     )
 
     // --- 7. Create EditScreenActions Instance (Largely unchanged) ---
@@ -292,15 +293,15 @@ fun EditScreenContentInternal(
     when {
         windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) -> {
             isMediumLayout = false // Update layout flag
-            LargeScreenLayout(state = stateForUiLayout, actions = actions)
+            LargeScreenLayout(state = stateForUiLayout, actions = actions, editingEmoji = uiState.editingEmoji)
         }
         windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND) -> {
             isMediumLayout = true // Update layout flag
-            LargeScreenLayout(state = stateForUiLayout, actions = actions) // Assuming Large handles Medium too
+            LargeScreenLayout(state = stateForUiLayout, actions = actions, editingEmoji = uiState.editingEmoji) // Assuming Large handles Medium too
         }
         else -> {
             isMediumLayout = false // Update layout flag
-            CompactScreenLayout(state = stateForUiLayout, actions = actions)
+            CompactScreenLayout(state = stateForUiLayout, actions = actions, editingEmoji = uiState.editingEmoji)
         }
     }
 

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -10,7 +10,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -50,9 +49,7 @@ fun EditScreenContentInternal(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     // --- 2. Hoist Remembered UI State (Local state managed within Composable) ---
-//    var showDialog by remember { mutableStateOf(false) }
     var showBottomSheet by remember { mutableStateOf(false) }
-    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true) // Often better for settings
     var isAddMode by remember { mutableStateOf(false) }
     var imageContainerSize by remember { mutableStateOf(IntSize.Zero) }
     var selectedIndexForEdit by remember { mutableIntStateOf(-1) } // -1 for Add, >=0 for Edit index
@@ -204,7 +201,6 @@ fun EditScreenContentInternal(
                 selectedIndexForEdit = -1 // Mark as Add
                 isAddMode = false // Exit add mode state after tap
                 viewModel.addEmoji(offset.x, offset.y, viewModel.getRandomEmoji(), 100f, 0f, startEditing = true)
-//                showDialog = true
             },
             onImageContainerMeasured = { size -> imageContainerSize = size },
             onPickImageClick = {
@@ -214,8 +210,6 @@ fun EditScreenContentInternal(
             },
             onClearImageClick = { viewModel.clearImage() },
             onEmojiCardClick = { index ->
-//                selectedIndexForEdit = index // Mark as Edit
-//                showDialog = true
                 viewModel.startEditing(index)
             },
             onAddEmojiCardClick = { isAddMode = true }, // Enter Add Mode
@@ -224,30 +218,6 @@ fun EditScreenContentInternal(
             onShareClick = { viewModel.shareImage() },
             onSaveClick = { viewModel.saveImageToGallery() },
             onSettingsClick = { showBottomSheet = true },
-
-//            // Dialog Actions
-//            onEditDialogConfirm = { newEmoji, newDiameter, newRotation ->
-//                if (selectedIndexForEdit >= 0) { // Editing
-//                    viewModel.updateEmoji(selectedIndexForEdit, newEmoji, newDiameter, newRotation)
-//                } else { // Adding
-//                    viewModel.addEmoji(
-//                        tapPositionForAdd.x,
-//                        tapPositionForAdd.y,
-//                        newEmoji,
-//                        newDiameter,
-//                        newRotation
-//                    )
-//                }
-//                showDialog = false
-//                selectedIndexForEdit = -1 // Reset index
-//            },
-//            onEditDialogDismiss = {
-//                showDialog = false
-//                selectedIndexForEdit = -1 // Reset index
-//                if (isAddMode) { // If dialog was dismissed during add mode tap, exit add mode
-//                    isAddMode = false
-//                }
-//            },
 
             // Bottom Sheet Actions
             onSettingsSheetDismiss = {
@@ -316,60 +286,4 @@ fun EditScreenContentInternal(
                 onDismissSettingsSheet = actions.onSettingsSheetDismiss)
         }
     }
-
-//    // --- 9. Render Common UI (Dialogs, Bottom Sheets) ---
-//    if (uiState.editingEmoji != null) {
-//        val editingStatus = uiState.editingEmoji!!
-//        // Get initial values for dialog from uiState or defaults
-////        val initialEmoji = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.emoji else viewModel.getRandomEmoji()
-////        val initialDiameter = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.diameter else 100f
-////        val initialRotation = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.angle else 0f
-//        // Calculate max diameter based on *original* bitmap dimensions from uiState
-//        val maxDiameter = remember(uiState.originalBitmap) {
-//            uiState.originalBitmap?.let { minOf(it.width, it.height) / 3f } ?: 500f
-//        }
-//
-//        ModalBottomSheet(
-//            onDismissRequest = actions.onCancelEditing,
-//            sheetState = bottomSheetState,
-//            dragHandle = {  },
-//            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
-//        ) {
-//            EditEmojiBottomSheetContent(
-//                initialEmoji = editingStatus.emoji,
-//                initialDiameter = editingStatus.diameter,
-//                initialRotation = editingStatus.angle,
-//                availableEmojis = uiState.predefinedEmojiOptions, // From uiState
-//                fontFamily = uiState.loadedFontFamily, // From uiState
-//                onConfirm = actions.onConfirmEditing, // Action
-//                onDismiss = actions.onCancelEditing,
-//                maxDiameter = maxDiameter,
-//                onValueChange = actions.onEditingValueChanged
-//            )
-//        }
-//    }
-
-//    if (showBottomSheet) {
-//        ModalBottomSheet(
-//            onDismissRequest = actions.onSettingsSheetDismiss,
-//            sheetState = bottomSheetState,
-//            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
-//        ) {
-//            // Embed the content composable, passing necessary data from uiState and local state
-//            SettingsBottomSheetContent(
-//                emojiOptions = uiState.predefinedEmojiOptions, // From uiState
-//                isEditingEmojiList = isEditingEmojiListInSheet, // Local state
-//                fontFamily = uiState.loadedFontFamily, // From uiState
-//                isAppIconHidden = uiState.isAppIconHidden, // From uiState
-//                availableFontNames = fontNames, // Derived value
-//                selectedFontIndex = selectedFontIndex, // Derived value
-//                onEditClick = actions.onEditPredefinedEmojisClick, // Action
-//                onEditConfirm = actions.onPredefinedEmojisEdited, // Action
-//                onHideIconToggle = actions.onHideIconToggle, // Action
-//                onFontSelected = actions.onFontSelected, // Action
-//                onAddFontClick = actions.onAddFontClick, // Action
-//                onRemoveFontClick = actions.onRemoveFontClick // Action
-//            )
-//        }
-//    }
 }

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -2,6 +2,7 @@ package top.maary.emojiface.ui.edit
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
 import android.os.Parcelable
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
@@ -25,10 +26,11 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.flow.collectLatest
 import top.maary.emojiface.R
-import top.maary.emojiface.ui.components.EditEmojiDialog
+import top.maary.emojiface.ui.components.EditEmojiBottomSheetContent
 import top.maary.emojiface.ui.components.SettingsBottomSheetContent
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
@@ -41,7 +43,7 @@ import top.maary.emojiface.util.getParcelableExtraCompat
 @Composable
 fun EditScreenContentInternal(
     // Assuming Hilt provides the ViewModel with UseCases injected
-    viewModel: EmojiViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
+    viewModel: EmojiViewModel = viewModel(),
     windowSizeClass: WindowSizeClass
 ) {
     val context = LocalContext.current
@@ -82,7 +84,7 @@ fun EditScreenContentInternal(
         val intent = activity?.intent
         if (intent?.action == Intent.ACTION_SEND && intent.type?.startsWith("image/") == true) {
             val sharedUri: Parcelable? = intent.getParcelableExtraCompat(Intent.EXTRA_STREAM)
-            (sharedUri as? android.net.Uri)?.let {
+            (sharedUri as? Uri)?.let {
                 // Check if already processed (using uiState.originalBitmap as indicator)
                 if (uiState.originalBitmap == null) {
                     viewModel.detect(it)
@@ -295,16 +297,23 @@ fun EditScreenContentInternal(
             uiState.originalBitmap?.let { minOf(it.width, it.height) / 3f } ?: 500f
         }
 
-        EditEmojiDialog(
-            initialEmoji = initialEmoji ?: "?",
-            initialDiameter = initialDiameter ?: 100f,
-            initialRotation = initialRotation ?: 0f,
-            maxDiameter = maxDiameter, // Use calculated max size
-            availableEmojis = uiState.predefinedEmojiOptions, // From uiState
-            fontFamily = uiState.loadedFontFamily, // From uiState
-            onConfirm = actions.onEditDialogConfirm, // Use action
-            onDismiss = actions.onEditDialogDismiss // Use action
-        )
+        ModalBottomSheet(
+            onDismissRequest = actions.onEditDialogDismiss,
+            sheetState = bottomSheetState,
+            dragHandle = {  },
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
+        ) {
+            EditEmojiBottomSheetContent(
+                initialEmoji = initialEmoji ?: "?",
+                initialDiameter = initialDiameter ?: 100f,
+                initialRotation = initialRotation ?: 0f,
+                availableEmojis = uiState.predefinedEmojiOptions, // From uiState
+                fontFamily = uiState.loadedFontFamily, // From uiState
+                onConfirm = actions.onEditDialogConfirm, // Action
+                onDismiss = actions.onEditDialogDismiss,
+                maxDiameter = maxDiameter // Action
+            )
+        }
     }
 
     if (showBottomSheet) {

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -30,7 +30,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.flow.collectLatest
 import top.maary.emojiface.R
-import top.maary.emojiface.ui.components.EditEmojiBottomSheetContent
 import top.maary.emojiface.ui.components.SettingsBottomSheetContent
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
@@ -306,37 +305,37 @@ fun EditScreenContentInternal(
         }
     }
 
-    // --- 9. Render Common UI (Dialogs, Bottom Sheets) ---
-    if (uiState.editingEmoji != null) {
-        val editingStatus = uiState.editingEmoji!!
-        // Get initial values for dialog from uiState or defaults
-//        val initialEmoji = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.emoji else viewModel.getRandomEmoji()
-//        val initialDiameter = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.diameter else 100f
-//        val initialRotation = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.angle else 0f
-        // Calculate max diameter based on *original* bitmap dimensions from uiState
-        val maxDiameter = remember(uiState.originalBitmap) {
-            uiState.originalBitmap?.let { minOf(it.width, it.height) / 3f } ?: 500f
-        }
-
-        ModalBottomSheet(
-            onDismissRequest = actions.onCancelEditing,
-            sheetState = bottomSheetState,
-            dragHandle = {  },
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
-        ) {
-            EditEmojiBottomSheetContent(
-                initialEmoji = editingStatus.emoji,
-                initialDiameter = editingStatus.diameter,
-                initialRotation = editingStatus.angle,
-                availableEmojis = uiState.predefinedEmojiOptions, // From uiState
-                fontFamily = uiState.loadedFontFamily, // From uiState
-                onConfirm = actions.onConfirmEditing, // Action
-                onDismiss = actions.onCancelEditing,
-                maxDiameter = maxDiameter,
-                onValueChange = actions.onEditingValueChanged
-            )
-        }
-    }
+//    // --- 9. Render Common UI (Dialogs, Bottom Sheets) ---
+//    if (uiState.editingEmoji != null) {
+//        val editingStatus = uiState.editingEmoji!!
+//        // Get initial values for dialog from uiState or defaults
+////        val initialEmoji = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.emoji else viewModel.getRandomEmoji()
+////        val initialDiameter = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.diameter else 100f
+////        val initialRotation = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.angle else 0f
+//        // Calculate max diameter based on *original* bitmap dimensions from uiState
+//        val maxDiameter = remember(uiState.originalBitmap) {
+//            uiState.originalBitmap?.let { minOf(it.width, it.height) / 3f } ?: 500f
+//        }
+//
+//        ModalBottomSheet(
+//            onDismissRequest = actions.onCancelEditing,
+//            sheetState = bottomSheetState,
+//            dragHandle = {  },
+//            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
+//        ) {
+//            EditEmojiBottomSheetContent(
+//                initialEmoji = editingStatus.emoji,
+//                initialDiameter = editingStatus.diameter,
+//                initialRotation = editingStatus.angle,
+//                availableEmojis = uiState.predefinedEmojiOptions, // From uiState
+//                fontFamily = uiState.loadedFontFamily, // From uiState
+//                onConfirm = actions.onConfirmEditing, // Action
+//                onDismiss = actions.onCancelEditing,
+//                maxDiameter = maxDiameter,
+//                onValueChange = actions.onEditingValueChanged
+//            )
+//        }
+//    }
 
     if (showBottomSheet) {
         ModalBottomSheet(

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -54,7 +54,7 @@ fun EditScreenContentInternal(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     // --- 2. Hoist Remembered UI State (Local state managed within Composable) ---
-    var showDialog by remember { mutableStateOf(false) }
+//    var showDialog by remember { mutableStateOf(false) }
     var showBottomSheet by remember { mutableStateOf(false) }
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true) // Often better for settings
     var isAddMode by remember { mutableStateOf(false) }
@@ -205,7 +205,8 @@ fun EditScreenContentInternal(
                 tapPositionForAdd = offset
                 selectedIndexForEdit = -1 // Mark as Add
                 isAddMode = false // Exit add mode state after tap
-                showDialog = true
+                viewModel.addEmoji(offset.x, offset.y, viewModel.getRandomEmoji(), 100f, 0f, startEditing = true)
+//                showDialog = true
             },
             onImageContainerMeasured = { size -> imageContainerSize = size },
             onPickImageClick = {
@@ -215,8 +216,9 @@ fun EditScreenContentInternal(
             },
             onClearImageClick = { viewModel.clearImage() },
             onEmojiCardClick = { index ->
-                selectedIndexForEdit = index // Mark as Edit
-                showDialog = true
+//                selectedIndexForEdit = index // Mark as Edit
+//                showDialog = true
+                viewModel.startEditing(index)
             },
             onAddEmojiCardClick = { isAddMode = true }, // Enter Add Mode
             onCloseClick = { activity?.finish() },
@@ -225,23 +227,29 @@ fun EditScreenContentInternal(
             onSaveClick = { viewModel.saveImageToGallery() },
             onSettingsClick = { showBottomSheet = true },
 
-            // Dialog Actions
-            onEditDialogConfirm = { newEmoji, newDiameter, newRotation ->
-                if (selectedIndexForEdit >= 0) { // Editing
-                    viewModel.updateEmoji(selectedIndexForEdit, newEmoji, newDiameter, newRotation)
-                } else { // Adding
-                    viewModel.addEmoji(tapPositionForAdd.x, tapPositionForAdd.y, newEmoji, newDiameter, newRotation)
-                }
-                showDialog = false
-                selectedIndexForEdit = -1 // Reset index
-            },
-            onEditDialogDismiss = {
-                showDialog = false
-                selectedIndexForEdit = -1 // Reset index
-                if (isAddMode) { // If dialog was dismissed during add mode tap, exit add mode
-                    isAddMode = false
-                }
-            },
+//            // Dialog Actions
+//            onEditDialogConfirm = { newEmoji, newDiameter, newRotation ->
+//                if (selectedIndexForEdit >= 0) { // Editing
+//                    viewModel.updateEmoji(selectedIndexForEdit, newEmoji, newDiameter, newRotation)
+//                } else { // Adding
+//                    viewModel.addEmoji(
+//                        tapPositionForAdd.x,
+//                        tapPositionForAdd.y,
+//                        newEmoji,
+//                        newDiameter,
+//                        newRotation
+//                    )
+//                }
+//                showDialog = false
+//                selectedIndexForEdit = -1 // Reset index
+//            },
+//            onEditDialogDismiss = {
+//                showDialog = false
+//                selectedIndexForEdit = -1 // Reset index
+//                if (isAddMode) { // If dialog was dismissed during add mode tap, exit add mode
+//                    isAddMode = false
+//                }
+//            },
 
             // Bottom Sheet Actions
             onSettingsSheetDismiss = {
@@ -265,7 +273,17 @@ fun EditScreenContentInternal(
                         viewModel.removeFontFromInternal(fontPathToRemove)
                     }
                 }
-            }
+            },
+            // --- 实时编辑 Actions ---
+            onEditingValueChanged = { emoji, diameter, rotation ->
+                viewModel.updateEditingEmoji(emoji, diameter, rotation)
+            },
+            onConfirmEditing = {
+                viewModel.confirmEditing()
+            },
+            onCancelEditing = {
+                viewModel.cancelEditing()
+            },
         )
     }
 
@@ -287,31 +305,33 @@ fun EditScreenContentInternal(
     }
 
     // --- 9. Render Common UI (Dialogs, Bottom Sheets) ---
-    if (showDialog) {
+    if (uiState.editingEmoji != null) {
+        val editingStatus = uiState.editingEmoji!!
         // Get initial values for dialog from uiState or defaults
-        val initialEmoji = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.emoji else viewModel.getRandomEmoji()
-        val initialDiameter = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.diameter else 100f
-        val initialRotation = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.angle else 0f
+//        val initialEmoji = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.emoji else viewModel.getRandomEmoji()
+//        val initialDiameter = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.diameter else 100f
+//        val initialRotation = if (selectedIndexForEdit >= 0) uiState.selectedEmojis.getOrNull(selectedIndexForEdit)?.angle else 0f
         // Calculate max diameter based on *original* bitmap dimensions from uiState
         val maxDiameter = remember(uiState.originalBitmap) {
             uiState.originalBitmap?.let { minOf(it.width, it.height) / 3f } ?: 500f
         }
 
         ModalBottomSheet(
-            onDismissRequest = actions.onEditDialogDismiss,
+            onDismissRequest = actions.onCancelEditing,
             sheetState = bottomSheetState,
             dragHandle = {  },
             containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
         ) {
             EditEmojiBottomSheetContent(
-                initialEmoji = initialEmoji ?: "?",
-                initialDiameter = initialDiameter ?: 100f,
-                initialRotation = initialRotation ?: 0f,
+                initialEmoji = editingStatus.emoji,
+                initialDiameter = editingStatus.diameter,
+                initialRotation = editingStatus.angle,
                 availableEmojis = uiState.predefinedEmojiOptions, // From uiState
                 fontFamily = uiState.loadedFontFamily, // From uiState
-                onConfirm = actions.onEditDialogConfirm, // Action
-                onDismiss = actions.onEditDialogDismiss,
-                maxDiameter = maxDiameter // Action
+                onConfirm = actions.onConfirmEditing, // Action
+                onDismiss = actions.onCancelEditing,
+                maxDiameter = maxDiameter,
+                onValueChange = actions.onEditingValueChanged
             )
         }
     }

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -10,8 +10,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,7 +28,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.flow.collectLatest
 import top.maary.emojiface.R
-import top.maary.emojiface.ui.components.SettingsBottomSheetContent
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
 import top.maary.emojiface.ui.edit.state.ShareEvent
@@ -293,15 +290,30 @@ fun EditScreenContentInternal(
     when {
         windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND) -> {
             isMediumLayout = false // Update layout flag
-            LargeScreenLayout(state = stateForUiLayout, actions = actions, editingEmoji = uiState.editingEmoji)
+            LargeScreenLayout(
+                state = stateForUiLayout,
+                actions = actions,
+                editingEmoji = uiState.editingEmoji,
+                showSettingsSheet = showBottomSheet,
+                onDismissSettingsSheet = actions.onSettingsSheetDismiss)
         }
         windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND) -> {
             isMediumLayout = true // Update layout flag
-            LargeScreenLayout(state = stateForUiLayout, actions = actions, editingEmoji = uiState.editingEmoji) // Assuming Large handles Medium too
+            LargeScreenLayout(
+                state = stateForUiLayout,
+                actions = actions,
+                editingEmoji = uiState.editingEmoji,
+                showSettingsSheet = showBottomSheet,
+                onDismissSettingsSheet = actions.onSettingsSheetDismiss)
         }
         else -> {
             isMediumLayout = false // Update layout flag
-            CompactScreenLayout(state = stateForUiLayout, actions = actions, editingEmoji = uiState.editingEmoji)
+            CompactScreenLayout(
+                state = stateForUiLayout,
+                actions = actions,
+                editingEmoji = uiState.editingEmoji,
+                showSettingsSheet = showBottomSheet,
+                onDismissSettingsSheet = actions.onSettingsSheetDismiss)
         }
     }
 
@@ -337,27 +349,27 @@ fun EditScreenContentInternal(
 //        }
 //    }
 
-    if (showBottomSheet) {
-        ModalBottomSheet(
-            onDismissRequest = actions.onSettingsSheetDismiss,
-            sheetState = bottomSheetState,
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
-        ) {
-            // Embed the content composable, passing necessary data from uiState and local state
-            SettingsBottomSheetContent(
-                emojiOptions = uiState.predefinedEmojiOptions, // From uiState
-                isEditingEmojiList = isEditingEmojiListInSheet, // Local state
-                fontFamily = uiState.loadedFontFamily, // From uiState
-                isAppIconHidden = uiState.isAppIconHidden, // From uiState
-                availableFontNames = fontNames, // Derived value
-                selectedFontIndex = selectedFontIndex, // Derived value
-                onEditClick = actions.onEditPredefinedEmojisClick, // Action
-                onEditConfirm = actions.onPredefinedEmojisEdited, // Action
-                onHideIconToggle = actions.onHideIconToggle, // Action
-                onFontSelected = actions.onFontSelected, // Action
-                onAddFontClick = actions.onAddFontClick, // Action
-                onRemoveFontClick = actions.onRemoveFontClick // Action
-            )
-        }
-    }
+//    if (showBottomSheet) {
+//        ModalBottomSheet(
+//            onDismissRequest = actions.onSettingsSheetDismiss,
+//            sheetState = bottomSheetState,
+//            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+//        ) {
+//            // Embed the content composable, passing necessary data from uiState and local state
+//            SettingsBottomSheetContent(
+//                emojiOptions = uiState.predefinedEmojiOptions, // From uiState
+//                isEditingEmojiList = isEditingEmojiListInSheet, // Local state
+//                fontFamily = uiState.loadedFontFamily, // From uiState
+//                isAppIconHidden = uiState.isAppIconHidden, // From uiState
+//                availableFontNames = fontNames, // Derived value
+//                selectedFontIndex = selectedFontIndex, // Derived value
+//                onEditClick = actions.onEditPredefinedEmojisClick, // Action
+//                onEditConfirm = actions.onPredefinedEmojisEdited, // Action
+//                onHideIconToggle = actions.onHideIconToggle, // Action
+//                onFontSelected = actions.onFontSelected, // Action
+//                onAddFontClick = actions.onAddFontClick, // Action
+//                onRemoveFontClick = actions.onRemoveFontClick // Action
+//            )
+//        }
+//    }
 }

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -22,26 +22,20 @@ import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.ModalDrawerSheet
-import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,18 +43,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import top.maary.emojiface.R
 import top.maary.emojiface.ui.components.ActionRow
 import top.maary.emojiface.ui.components.DisplayPane
 import top.maary.emojiface.ui.components.EditEmojiBottomSheetContent
-import top.maary.emojiface.ui.components.EditEmojiSideSheetContent
 import top.maary.emojiface.ui.components.EmojiCard
 import top.maary.emojiface.ui.components.SettingsBottomSheetContent
-import top.maary.emojiface.ui.components.SettingsSideSheetContent
+import top.maary.emojiface.ui.components.SideSheet
+import top.maary.emojiface.ui.components.SideSheetContent
 import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
@@ -120,7 +112,10 @@ fun CompactScreenLayout(
         ) {
             // --- 圖片顯示區域 ---
             DisplayPane(
-                modifier = Modifier.weight(1f).fillMaxWidth().padding(8.dp),
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(8.dp),
                 state = state,
                 actions = actions,
                 editingEmoji = editingEmoji
@@ -171,7 +166,6 @@ fun CompactScreenLayout(
             ActionRow(state = state, actions = actions)
 
             Spacer(modifier = Modifier.height(innerPadding.calculateBottomPadding()))
-//            }
 
         }
     }
@@ -238,274 +232,134 @@ fun LargeScreenLayout(
     showSettingsSheet: Boolean,
     onDismissSettingsSheet: () -> Unit
 ) {
-//    Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
-//    ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
-//        NavigationSuiteScaffold(
-//            navigationSuiteItems = {
-//                // --- Navigation Rail Items ---
-//                item(
-//                    icon = {
-//                        Icon(
-//                            imageVector = Icons.Outlined.Close,
-//                            contentDescription = stringResource(R.string.exit)
-//                        )
-//                    },
-//                    label = { Text(stringResource(R.string.exit)) }, // Show label in NavRail
-//                    selected = false, // Never selected state
-//                    onClick = actions.onCloseClick // Use action
-//                )
-//                // Show clear button only if an image is loaded
-//                if (state.displayedBitmap != null) {
-//                    item(
-//                        icon = {
-//                            Icon(
-//                                imageVector = Icons.Outlined.DeleteSweep,
-//                                contentDescription = stringResource(R.string.clear_photo)
-//                            )
-//                        },
-//                        // label = { Text("Clear") }, // Optional label
-//                        selected = false,
-//                        onClick = actions.onClearImageClick // Use action
-//                    )
-//                }
-//            },
-//            layoutType = NavigationSuiteType.NavigationRail, // Explicitly set type
-//            navigationSuiteColors = NavigationSuiteDefaults.colors( // Consistent colors
-//                navigationRailContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
-//                navigationRailContentColor = MaterialTheme.colorScheme.tertiary,
-//            )
-//        ) {
-//            // --- Main Content Area (beside NavRail) ---
-//            Row(
-//                modifier = Modifier
-//                    .fillMaxSize().padding(innerPadding) // Check if needed depending on NavSuiteScaffold behavior
-//            ) {
-//                // --- Image Display Area (Larger Portion) ---
-//                DisplayPane(modifier = Modifier.weight(2f).fillMaxHeight(), state = state, actions = actions, editingEmoji = editingEmoji)
-//
-//                // --- Side Panel (Smaller Portion) ---
-//                Card(
-//                    modifier = Modifier
-//                        .weight(1f) // Takes 1/3 of the width
-//                        .fillMaxHeight()
-//                        .padding(end = 8.dp), // Padding around card
-//                    colors = CardDefaults.cardColors( // Consistent card color
-//                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-//                    )
-//                ) {
-//                    Column(
-//                        modifier = Modifier.fillMaxHeight(), // Column fills the card height
-//                        verticalArrangement = Arrangement.SpaceBetween // Pushes grid up and buttons down
-//                    ) {
-//                        // --- Emoji Grid ---
-//                        LazyVerticalGrid(
-//                            columns = GridCells.Adaptive(minSize = 76.dp), // Adaptive columns
-//                            modifier = Modifier.weight(1f) // Grid takes available space
-//                        ) {
-//                            itemsIndexed(state.emojiDetections) { index, detection ->
-//                                EmojiCard(
-//                                    emoji = detection.emoji,
-//                                    onClick = { actions.onEmojiCardClick(index) }, // Use action
-//                                    fontFamily = state.fontFamily,
-//                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-//                                    hPadding = 8.dp,
-//                                    vPadding = 8.dp
-//                                )
-//                            }
-//                            // Show Add button only if an image is present
-//                            if (state.displayedBitmap != null) {
-//                                item {
-//                                    EmojiCard(
-//                                        emoji = "➕",
-//                                        onClick = actions.onAddEmojiCardClick, // Use action
-//                                        clickable = true,
-//                                        fontFamily = state.fontFamily,
-//                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-//                                        hPadding = 8.dp,
-//                                        vPadding = 8.dp
-//                                    )
-//                                }
-//                            }
-//                        }
-//
-//                        // --- Action Buttons Area (at the bottom of the card) ---
-//                        ActionRow(state = state, actions = actions)
-//                    }
-//                }
-//            }
-//        }
-//    }
-    val isDrawerOpenRequest = editingEmoji != null || showSettingsSheet
-    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    // 1. 逻辑更清晰：判断是否需要显示 SideSheet
+    val showSideSheet = editingEmoji != null || showSettingsSheet
 
-    // 2. 使用 LaunchedEffect 同步 ViewModel 状态 和 SideSheet 状态
-    LaunchedEffect(isDrawerOpenRequest) {
-        if (isDrawerOpenRequest) {
-            drawerState.open()
+    // 2. 决定关闭时应该执行哪个动作
+    val onDismiss = {
+        if (editingEmoji != null) {
+            actions.onCancelEditing()
         } else {
-            drawerState.close()
+            onDismissSettingsSheet()
         }
     }
 
-    // 3. 监听 SideSheet 的关闭事件 (比如点击外部)，并通知 ViewModel
-    LaunchedEffect(drawerState.currentValue) {
-        if (drawerState.currentValue == DrawerValue.Closed && isDrawerOpenRequest) {
-            if (editingEmoji != null) {
-                actions.onCancelEditing()
-            } else {
-                onDismissSettingsSheet()
-            }
+    // 3. 使用 AppSideSheet 容器，传入状态和内容
+    SideSheet(
+        showSheet = showSideSheet,
+        onDismissSheet = onDismiss,
+        sheetContent = {
+            // 调用新的内容 Composable
+            SideSheetContent(
+                state = state,
+                actions = actions,
+                editingEmoji = editingEmoji,
+                showSettingsSheet = showSettingsSheet
+            )
         }
-    }
-
-    // 4. 使用 CompositionLocalProvider 将抽屉强制设置为从右向左 (RTL) 弹出
-    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
-        ModalNavigationDrawer(
-            drawerState = drawerState,
-            gesturesEnabled = isDrawerOpenRequest, // 抽屉打开时才允许手势
-            drawerContent = {
-                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-                    ModalDrawerSheet (
-                        drawerContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest
-                    ) {
-                            // 动态切换抽屉内容
-                            if (editingEmoji != null) {
-                                // --- 显示 Emoji 编辑器 ---
-                                val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
-                                EditEmojiSideSheetContent (
-                                    initialEmoji = editingEmoji.emoji,
-                                    initialDiameter = editingEmoji.diameter,
-                                    initialRotation = editingEmoji.angle,
-                                    availableEmojis = state.predefinedEmojiList ?: emptyList(),
-                                    fontFamily = state.fontFamily,
-                                    onConfirm = actions.onConfirmEditing,
-                                    onDismiss = actions.onCancelEditing,
-                                    maxDiameter = maxDiameter,
-                                    onValueChange = actions.onEditingValueChanged
-                                )
-                            } else if (showSettingsSheet) {
-                                // --- 显示设置面板 ---
-                                var isEditingEmojiListInSheet by remember { mutableStateOf(false) }
-                                SettingsSideSheetContent (
-                                    emojiOptions = state.predefinedEmojiList ?: emptyList(),
-                                    isEditingEmojiList = isEditingEmojiListInSheet,
-                                    fontFamily = state.fontFamily,
-                                    isAppIconHidden = state.isAppIconHidden,
-                                    availableFontNames = state.availableFontNames ?: emptyList(),
-                                    selectedFontIndex = state.selectedFontIndex,
-                                    onEditClick = { isEditingEmojiListInSheet = true },
-                                    onEditConfirm = { newEmojiList ->
-                                        actions.onPredefinedEmojisEdited(newEmojiList)
-                                        isEditingEmojiListInSheet = false
-                                    },
-                                    onHideIconToggle = actions.onHideIconToggle,
-                                    onFontSelected = actions.onFontSelected,
-                                    onAddFontClick = actions.onAddFontClick,
-                                    onRemoveFontClick = actions.onRemoveFontClick
-                                )
-                            }
-
-                    }
-                }
-            }
-        ) {
-            // 5. 将原有的 Scaffold 和 NavigationSuiteScaffold 作为主内容
-            // 同样，恢复 LTR 方向以确保主屏幕布局正常
-            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-                Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
-                ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
-                    NavigationSuiteScaffold(
-                        navigationSuiteItems = {
-                            // --- Navigation Rail Items ---
-                            item(
-                                icon = {
-                                    Icon(
-                                        imageVector = Icons.Outlined.Close,
-                                        contentDescription = stringResource(R.string.exit)
-                                    )
-                                },
-                                label = { Text(stringResource(R.string.exit)) }, // Show label in NavRail
-                                selected = false, // Never selected state
-                                onClick = actions.onCloseClick // Use action
+    ) {
+        Scaffold(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
+        ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
+            NavigationSuiteScaffold(
+                navigationSuiteItems = {
+                    // --- Navigation Rail Items ---
+                    item(
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Close,
+                                contentDescription = stringResource(R.string.exit)
                             )
-                            // Show clear button only if an image is loaded
-                            if (state.displayedBitmap != null) {
-                                item(
-                                    icon = {
-                                        Icon(
-                                            imageVector = Icons.Outlined.DeleteSweep,
-                                            contentDescription = stringResource(R.string.clear_photo)
-                                        )
-                                    },
-                                    // label = { Text("Clear") }, // Optional label
-                                    selected = false,
-                                    onClick = actions.onClearImageClick // Use action
-                                )
-                            }
                         },
-                        layoutType = NavigationSuiteType.NavigationRail, // Explicitly set type
-                        navigationSuiteColors = NavigationSuiteDefaults.colors( // Consistent colors
-                            navigationRailContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                            navigationRailContentColor = MaterialTheme.colorScheme.tertiary,
+                        label = { Text(stringResource(R.string.exit)) }, // Show label in NavRail
+                        selected = false, // Never selected state
+                        onClick = actions.onCloseClick // Use action
+                    )
+                    // Show clear button only if an image is loaded
+                    if (state.displayedBitmap != null) {
+                        item(
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.DeleteSweep,
+                                    contentDescription = stringResource(R.string.clear_photo)
+                                )
+                            },
+                            // label = { Text("Clear") }, // Optional label
+                            selected = false,
+                            onClick = actions.onClearImageClick // Use action
+                        )
+                    }
+                },
+                layoutType = NavigationSuiteType.NavigationRail, // Explicitly set type
+                navigationSuiteColors = NavigationSuiteDefaults.colors(
+                    // Consistent colors
+                    navigationRailContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    navigationRailContentColor = MaterialTheme.colorScheme.tertiary,
+                )
+            ) {
+                // --- Main Content Area (beside NavRail) ---
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding) // Check if needed depending on NavSuiteScaffold behavior
+                ) {
+                    // --- Image Display Area (Larger Portion) ---
+                    DisplayPane(
+                        modifier = Modifier
+                            .weight(2f)
+                            .fillMaxHeight(),
+                        state = state,
+                        actions = actions,
+                        editingEmoji = editingEmoji
+                    )
+
+                    // --- Side Panel (Smaller Portion) ---
+                    Card(
+                        modifier = Modifier
+                            .weight(1f) // Takes 1/3 of the width
+                            .fillMaxHeight()
+                            .padding(end = 8.dp), // Padding around card
+                        colors = CardDefaults.cardColors( // Consistent card color
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
                         )
                     ) {
-                        // --- Main Content Area (beside NavRail) ---
-                        Row(
-                            modifier = Modifier
-                                .fillMaxSize().padding(innerPadding) // Check if needed depending on NavSuiteScaffold behavior
+                        Column(
+                            modifier = Modifier.fillMaxHeight(), // Column fills the card height
+                            verticalArrangement = Arrangement.SpaceBetween // Pushes grid up and buttons down
                         ) {
-                            // --- Image Display Area (Larger Portion) ---
-                            DisplayPane(modifier = Modifier.weight(2f).fillMaxHeight(), state = state, actions = actions, editingEmoji = editingEmoji)
-
-                            // --- Side Panel (Smaller Portion) ---
-                            Card(
-                                modifier = Modifier
-                                    .weight(1f) // Takes 1/3 of the width
-                                    .fillMaxHeight()
-                                    .padding(end = 8.dp), // Padding around card
-                                colors = CardDefaults.cardColors( // Consistent card color
-                                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                                )
+                            // --- Emoji Grid ---
+                            LazyVerticalGrid(
+                                columns = GridCells.Adaptive(minSize = 76.dp), // Adaptive columns
+                                modifier = Modifier.weight(1f) // Grid takes available space
                             ) {
-                                Column(
-                                    modifier = Modifier.fillMaxHeight(), // Column fills the card height
-                                    verticalArrangement = Arrangement.SpaceBetween // Pushes grid up and buttons down
-                                ) {
-                                    // --- Emoji Grid ---
-                                    LazyVerticalGrid(
-                                        columns = GridCells.Adaptive(minSize = 76.dp), // Adaptive columns
-                                        modifier = Modifier.weight(1f) // Grid takes available space
-                                    ) {
-                                        itemsIndexed(state.emojiDetections) { index, detection ->
-                                            EmojiCard(
-                                                emoji = detection.emoji,
-                                                onClick = { actions.onEmojiCardClick(index) }, // Use action
-                                                fontFamily = state.fontFamily,
-                                                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                                hPadding = 8.dp,
-                                                vPadding = 8.dp
-                                            )
-                                        }
-                                        // Show Add button only if an image is present
-                                        if (state.displayedBitmap != null) {
-                                            item {
-                                                EmojiCard(
-                                                    emoji = "➕",
-                                                    onClick = actions.onAddEmojiCardClick, // Use action
-                                                    clickable = true,
-                                                    fontFamily = state.fontFamily,
-                                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                                    hPadding = 8.dp,
-                                                    vPadding = 8.dp
-                                                )
-                                            }
-                                        }
+                                itemsIndexed(state.emojiDetections) { index, detection ->
+                                    EmojiCard(
+                                        emoji = detection.emoji,
+                                        onClick = { actions.onEmojiCardClick(index) }, // Use action
+                                        fontFamily = state.fontFamily,
+                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                        hPadding = 8.dp,
+                                        vPadding = 8.dp
+                                    )
+                                }
+                                // Show Add button only if an image is present
+                                if (state.displayedBitmap != null) {
+                                    item {
+                                        EmojiCard(
+                                            emoji = "➕",
+                                            onClick = actions.onAddEmojiCardClick, // Use action
+                                            clickable = true,
+                                            fontFamily = state.fontFamily,
+                                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                            hPadding = 8.dp,
+                                            vPadding = 8.dp
+                                        )
                                     }
-
-                                    // --- Action Buttons Area (at the bottom of the card) ---
-                                    ActionRow(state = state, actions = actions)
                                 }
                             }
+
+                            // --- Action Buttons Area (at the bottom of the card) ---
+                            ActionRow(state = state, actions = actions)
                         }
                     }
                 }

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -22,26 +22,38 @@ import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import top.maary.emojiface.R
 import top.maary.emojiface.ui.components.ActionRow
 import top.maary.emojiface.ui.components.DisplayPane
+import top.maary.emojiface.ui.components.EditEmojiBottomSheetContent
+import top.maary.emojiface.ui.components.EditEmojiSideSheetContent
 import top.maary.emojiface.ui.components.EmojiCard
 import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.EditScreenActions
@@ -95,7 +107,12 @@ fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions, edit
                 .padding(top = innerPadding.calculateTopPadding()) // 應用 Scaffold 的內邊距
         ) {
             // --- 圖片顯示區域 ---
-            DisplayPane(modifier = Modifier.weight(1f).fillMaxWidth().padding(8.dp), state = state, actions = actions, editingEmoji = editingEmoji)
+            DisplayPane(
+                modifier = Modifier.weight(1f).fillMaxWidth().padding(8.dp),
+                state = state,
+                actions = actions,
+                editingEmoji = editingEmoji
+            )
 
             if (state.displayedBitmap != null) {
                 Card(
@@ -138,110 +155,286 @@ fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions, edit
                 }
             }
 
-                // --- 底部操作按鈕區域 ---
-                ActionRow(state = state, actions = actions)
+            // --- 底部操作按鈕區域 ---
+            ActionRow(state = state, actions = actions)
 
-                Spacer(modifier = Modifier.height(innerPadding.calculateBottomPadding()))
+            Spacer(modifier = Modifier.height(innerPadding.calculateBottomPadding()))
 //            }
 
+        }
+    }
+    if (editingEmoji != null) {
+        val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
+
+        ModalBottomSheet(
+            onDismissRequest = actions.onCancelEditing,
+            sheetState = bottomSheetState,
+            dragHandle = { },
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
+        ) {
+            // 完全复用现有的 Composable
+            EditEmojiBottomSheetContent(
+                initialEmoji = editingEmoji.emoji,
+                initialDiameter = editingEmoji.diameter,
+                initialRotation = editingEmoji.angle,
+                availableEmojis = state.predefinedEmojiList ?: emptyList(),
+                fontFamily = state.fontFamily,
+                onConfirm = actions.onConfirmEditing,
+                onDismiss = actions.onCancelEditing,
+                maxDiameter = maxDiameter,
+                onValueChange = actions.onEditingValueChanged
+            )
         }
     }
 }
 
 @Composable
 fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions, editingEmoji: EmojiDetection?) {
-    Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
-    ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
-        NavigationSuiteScaffold(
-            navigationSuiteItems = {
-                // --- Navigation Rail Items ---
-                item(
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Close,
-                            contentDescription = stringResource(R.string.exit)
-                        )
-                    },
-                    label = { Text(stringResource(R.string.exit)) }, // Show label in NavRail
-                    selected = false, // Never selected state
-                    onClick = actions.onCloseClick // Use action
-                )
-                // Show clear button only if an image is loaded
-                if (state.displayedBitmap != null) {
-                    item(
-                        icon = {
-                            Icon(
-                                imageVector = Icons.Outlined.DeleteSweep,
-                                contentDescription = stringResource(R.string.clear_photo)
-                            )
-                        },
-                        // label = { Text("Clear") }, // Optional label
-                        selected = false,
-                        onClick = actions.onClearImageClick // Use action
-                    )
-                }
-            },
-            layoutType = NavigationSuiteType.NavigationRail, // Explicitly set type
-            navigationSuiteColors = NavigationSuiteDefaults.colors( // Consistent colors
-                navigationRailContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                navigationRailContentColor = MaterialTheme.colorScheme.tertiary,
-            )
-        ) {
-            // --- Main Content Area (beside NavRail) ---
-            Row(
-                modifier = Modifier
-                    .fillMaxSize().padding(innerPadding) // Check if needed depending on NavSuiteScaffold behavior
-            ) {
-                // --- Image Display Area (Larger Portion) ---
-                DisplayPane(modifier = Modifier.weight(2f).fillMaxHeight(), state = state, actions = actions, editingEmoji = editingEmoji)
+//    Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
+//    ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
+//        NavigationSuiteScaffold(
+//            navigationSuiteItems = {
+//                // --- Navigation Rail Items ---
+//                item(
+//                    icon = {
+//                        Icon(
+//                            imageVector = Icons.Outlined.Close,
+//                            contentDescription = stringResource(R.string.exit)
+//                        )
+//                    },
+//                    label = { Text(stringResource(R.string.exit)) }, // Show label in NavRail
+//                    selected = false, // Never selected state
+//                    onClick = actions.onCloseClick // Use action
+//                )
+//                // Show clear button only if an image is loaded
+//                if (state.displayedBitmap != null) {
+//                    item(
+//                        icon = {
+//                            Icon(
+//                                imageVector = Icons.Outlined.DeleteSweep,
+//                                contentDescription = stringResource(R.string.clear_photo)
+//                            )
+//                        },
+//                        // label = { Text("Clear") }, // Optional label
+//                        selected = false,
+//                        onClick = actions.onClearImageClick // Use action
+//                    )
+//                }
+//            },
+//            layoutType = NavigationSuiteType.NavigationRail, // Explicitly set type
+//            navigationSuiteColors = NavigationSuiteDefaults.colors( // Consistent colors
+//                navigationRailContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
+//                navigationRailContentColor = MaterialTheme.colorScheme.tertiary,
+//            )
+//        ) {
+//            // --- Main Content Area (beside NavRail) ---
+//            Row(
+//                modifier = Modifier
+//                    .fillMaxSize().padding(innerPadding) // Check if needed depending on NavSuiteScaffold behavior
+//            ) {
+//                // --- Image Display Area (Larger Portion) ---
+//                DisplayPane(modifier = Modifier.weight(2f).fillMaxHeight(), state = state, actions = actions, editingEmoji = editingEmoji)
+//
+//                // --- Side Panel (Smaller Portion) ---
+//                Card(
+//                    modifier = Modifier
+//                        .weight(1f) // Takes 1/3 of the width
+//                        .fillMaxHeight()
+//                        .padding(end = 8.dp), // Padding around card
+//                    colors = CardDefaults.cardColors( // Consistent card color
+//                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+//                    )
+//                ) {
+//                    Column(
+//                        modifier = Modifier.fillMaxHeight(), // Column fills the card height
+//                        verticalArrangement = Arrangement.SpaceBetween // Pushes grid up and buttons down
+//                    ) {
+//                        // --- Emoji Grid ---
+//                        LazyVerticalGrid(
+//                            columns = GridCells.Adaptive(minSize = 76.dp), // Adaptive columns
+//                            modifier = Modifier.weight(1f) // Grid takes available space
+//                        ) {
+//                            itemsIndexed(state.emojiDetections) { index, detection ->
+//                                EmojiCard(
+//                                    emoji = detection.emoji,
+//                                    onClick = { actions.onEmojiCardClick(index) }, // Use action
+//                                    fontFamily = state.fontFamily,
+//                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+//                                    hPadding = 8.dp,
+//                                    vPadding = 8.dp
+//                                )
+//                            }
+//                            // Show Add button only if an image is present
+//                            if (state.displayedBitmap != null) {
+//                                item {
+//                                    EmojiCard(
+//                                        emoji = "➕",
+//                                        onClick = actions.onAddEmojiCardClick, // Use action
+//                                        clickable = true,
+//                                        fontFamily = state.fontFamily,
+//                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+//                                        hPadding = 8.dp,
+//                                        vPadding = 8.dp
+//                                    )
+//                                }
+//                            }
+//                        }
+//
+//                        // --- Action Buttons Area (at the bottom of the card) ---
+//                        ActionRow(state = state, actions = actions)
+//                    }
+//                }
+//            }
+//        }
+//    }
+    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
-                // --- Side Panel (Smaller Portion) ---
-                Card(
-                    modifier = Modifier
-                        .weight(1f) // Takes 1/3 of the width
-                        .fillMaxHeight()
-                        .padding(end = 8.dp), // Padding around card
-                    colors = CardDefaults.cardColors( // Consistent card color
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                    )
-                ) {
-                    Column(
-                        modifier = Modifier.fillMaxHeight(), // Column fills the card height
-                        verticalArrangement = Arrangement.SpaceBetween // Pushes grid up and buttons down
+    // 2. 使用 LaunchedEffect 同步 ViewModel 状态 和 SideSheet 状态
+    LaunchedEffect(editingEmoji) {
+        if (editingEmoji != null) {
+            drawerState.open()
+        } else {
+            drawerState.close()
+        }
+    }
+
+    // 3. 监听 SideSheet 的关闭事件 (比如点击外部)，并通知 ViewModel
+    LaunchedEffect(drawerState.currentValue) {
+        // 如果用户关闭了抽屉，但 ViewModel 的状态仍然是“正在编辑”，则调用取消操作
+        if (drawerState.currentValue == DrawerValue.Closed && editingEmoji != null) {
+            actions.onCancelEditing()
+        }
+    }
+
+    // 4. 使用 CompositionLocalProvider 将抽屉强制设置为从右向左 (RTL) 弹出
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            gesturesEnabled = editingEmoji != null, // 仅在编辑时允许手势
+            drawerContent = {
+                // 在抽屉内容内部，将布局方向恢复为从左到右 (LTR)，以免影响内容本身
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    ModalDrawerSheet(
+                        modifier = Modifier.width(360.dp) // 设置 SideSheet 的宽度
                     ) {
-                        // --- Emoji Grid ---
-                        LazyVerticalGrid(
-                            columns = GridCells.Adaptive(minSize = 76.dp), // Adaptive columns
-                            modifier = Modifier.weight(1f) // Grid takes available space
-                        ) {
-                            itemsIndexed(state.emojiDetections) { index, detection ->
-                                EmojiCard(
-                                    emoji = detection.emoji,
-                                    onClick = { actions.onEmojiCardClick(index) }, // Use action
-                                    fontFamily = state.fontFamily,
-                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                    hPadding = 8.dp,
-                                    vPadding = 8.dp
+                        if (editingEmoji != null) {
+                            val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
+                            // 再次复用完全相同的 EditEmojiBottomSheetContent
+                            EditEmojiSideSheetContent(
+                                initialEmoji = editingEmoji.emoji,
+                                initialDiameter = editingEmoji.diameter,
+                                initialRotation = editingEmoji.angle,
+                                availableEmojis = state.predefinedEmojiList ?: emptyList(),
+                                fontFamily = state.fontFamily,
+                                onConfirm = actions.onConfirmEditing,
+                                onDismiss = actions.onCancelEditing,
+                                maxDiameter = maxDiameter,
+                                onValueChange = actions.onEditingValueChanged
+                            )
+                        }
+                    }
+                }
+            }
+        ) {
+            // 5. 将原有的 Scaffold 和 NavigationSuiteScaffold 作为主内容
+            // 同样，恢复 LTR 方向以确保主屏幕布局正常
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
+                ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
+                    NavigationSuiteScaffold(
+                        navigationSuiteItems = {
+                            // --- Navigation Rail Items ---
+                            item(
+                                icon = {
+                                    Icon(
+                                        imageVector = Icons.Outlined.Close,
+                                        contentDescription = stringResource(R.string.exit)
+                                    )
+                                },
+                                label = { Text(stringResource(R.string.exit)) }, // Show label in NavRail
+                                selected = false, // Never selected state
+                                onClick = actions.onCloseClick // Use action
+                            )
+                            // Show clear button only if an image is loaded
+                            if (state.displayedBitmap != null) {
+                                item(
+                                    icon = {
+                                        Icon(
+                                            imageVector = Icons.Outlined.DeleteSweep,
+                                            contentDescription = stringResource(R.string.clear_photo)
+                                        )
+                                    },
+                                    // label = { Text("Clear") }, // Optional label
+                                    selected = false,
+                                    onClick = actions.onClearImageClick // Use action
                                 )
                             }
-                            // Show Add button only if an image is present
-                            if (state.displayedBitmap != null) {
-                                item {
-                                    EmojiCard(
-                                        emoji = "➕",
-                                        onClick = actions.onAddEmojiCardClick, // Use action
-                                        clickable = true,
-                                        fontFamily = state.fontFamily,
-                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                        hPadding = 8.dp,
-                                        vPadding = 8.dp
-                                    )
+                        },
+                        layoutType = NavigationSuiteType.NavigationRail, // Explicitly set type
+                        navigationSuiteColors = NavigationSuiteDefaults.colors( // Consistent colors
+                            navigationRailContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                            navigationRailContentColor = MaterialTheme.colorScheme.tertiary,
+                        )
+                    ) {
+                        // --- Main Content Area (beside NavRail) ---
+                        Row(
+                            modifier = Modifier
+                                .fillMaxSize().padding(innerPadding) // Check if needed depending on NavSuiteScaffold behavior
+                        ) {
+                            // --- Image Display Area (Larger Portion) ---
+                            DisplayPane(modifier = Modifier.weight(2f).fillMaxHeight(), state = state, actions = actions, editingEmoji = editingEmoji)
+
+                            // --- Side Panel (Smaller Portion) ---
+                            Card(
+                                modifier = Modifier
+                                    .weight(1f) // Takes 1/3 of the width
+                                    .fillMaxHeight()
+                                    .padding(end = 8.dp), // Padding around card
+                                colors = CardDefaults.cardColors( // Consistent card color
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                                )
+                            ) {
+                                Column(
+                                    modifier = Modifier.fillMaxHeight(), // Column fills the card height
+                                    verticalArrangement = Arrangement.SpaceBetween // Pushes grid up and buttons down
+                                ) {
+                                    // --- Emoji Grid ---
+                                    LazyVerticalGrid(
+                                        columns = GridCells.Adaptive(minSize = 76.dp), // Adaptive columns
+                                        modifier = Modifier.weight(1f) // Grid takes available space
+                                    ) {
+                                        itemsIndexed(state.emojiDetections) { index, detection ->
+                                            EmojiCard(
+                                                emoji = detection.emoji,
+                                                onClick = { actions.onEmojiCardClick(index) }, // Use action
+                                                fontFamily = state.fontFamily,
+                                                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                                hPadding = 8.dp,
+                                                vPadding = 8.dp
+                                            )
+                                        }
+                                        // Show Add button only if an image is present
+                                        if (state.displayedBitmap != null) {
+                                            item {
+                                                EmojiCard(
+                                                    emoji = "➕",
+                                                    onClick = actions.onAddEmojiCardClick, // Use action
+                                                    clickable = true,
+                                                    fontFamily = state.fontFamily,
+                                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                                    hPadding = 8.dp,
+                                                    vPadding = 8.dp
+                                                )
+                                            }
+                                        }
+                                    }
+
+                                    // --- Action Buttons Area (at the bottom of the card) ---
+                                    ActionRow(state = state, actions = actions)
                                 }
                             }
                         }
-
-                        // --- Action Buttons Area (at the bottom of the card) ---
-                        ActionRow(state = state, actions = actions)
                     }
                 }
             }

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -43,12 +43,13 @@ import top.maary.emojiface.R
 import top.maary.emojiface.ui.components.ActionRow
 import top.maary.emojiface.ui.components.DisplayPane
 import top.maary.emojiface.ui.components.EmojiCard
+import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions) {
+fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions, editingEmoji: EmojiDetection?) {
     // TopAppBar 滾動行為
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
 
@@ -94,7 +95,7 @@ fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions) {
                 .padding(top = innerPadding.calculateTopPadding()) // 應用 Scaffold 的內邊距
         ) {
             // --- 圖片顯示區域 ---
-            DisplayPane(modifier = Modifier.weight(1f).fillMaxWidth().padding(8.dp), state = state, actions = actions)
+            DisplayPane(modifier = Modifier.weight(1f).fillMaxWidth().padding(8.dp), state = state, actions = actions, editingEmoji = editingEmoji)
 
             if (state.displayedBitmap != null) {
                 Card(
@@ -148,7 +149,7 @@ fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions) {
 }
 
 @Composable
-fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions) {
+fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions, editingEmoji: EmojiDetection?) {
     Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
     ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
         NavigationSuiteScaffold(
@@ -192,7 +193,7 @@ fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions) {
                     .fillMaxSize().padding(innerPadding) // Check if needed depending on NavSuiteScaffold behavior
             ) {
                 // --- Image Display Area (Larger Portion) ---
-                DisplayPane(modifier = Modifier.weight(2f).fillMaxHeight(), state = state, actions = actions)
+                DisplayPane(modifier = Modifier.weight(2f).fillMaxHeight(), state = state, actions = actions, editingEmoji = editingEmoji)
 
                 // --- Side Panel (Smaller Portion) ---
                 Card(

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -42,6 +42,10 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -55,13 +59,21 @@ import top.maary.emojiface.ui.components.DisplayPane
 import top.maary.emojiface.ui.components.EditEmojiBottomSheetContent
 import top.maary.emojiface.ui.components.EditEmojiSideSheetContent
 import top.maary.emojiface.ui.components.EmojiCard
+import top.maary.emojiface.ui.components.SettingsBottomSheetContent
+import top.maary.emojiface.ui.components.SettingsSideSheetContent
 import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions, editingEmoji: EmojiDetection?) {
+fun CompactScreenLayout(
+    state: EditScreenState,
+    actions: EditScreenActions,
+    editingEmoji: EmojiDetection?,
+    showSettingsSheet: Boolean,
+    onDismissSettingsSheet: () -> Unit
+) {
     // TopAppBar 滾動行為
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
 
@@ -187,10 +199,45 @@ fun CompactScreenLayout(state: EditScreenState, actions: EditScreenActions, edit
             )
         }
     }
+    if (showSettingsSheet) {
+        val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        // 将这个状态管理移到这里，使其生命周期与 Sheet 绑定
+        var isEditingEmojiListInSheet by remember { mutableStateOf(false) }
+
+        ModalBottomSheet(
+            onDismissRequest = onDismissSettingsSheet, // 使用传递进来的 dismiss 函数
+            sheetState = bottomSheetState,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+        ) {
+            SettingsBottomSheetContent(
+                emojiOptions = state.predefinedEmojiList ?: emptyList(),
+                isEditingEmojiList = isEditingEmojiListInSheet,
+                fontFamily = state.fontFamily,
+                isAppIconHidden = state.isAppIconHidden,
+                availableFontNames = state.availableFontNames ?: emptyList(),
+                selectedFontIndex = state.selectedFontIndex,
+                onEditClick = { isEditingEmojiListInSheet = true },
+                onEditConfirm = { newEmojiList ->
+                    actions.onPredefinedEmojisEdited(newEmojiList)
+                    isEditingEmojiListInSheet = false
+                },
+                onHideIconToggle = actions.onHideIconToggle,
+                onFontSelected = actions.onFontSelected,
+                onAddFontClick = actions.onAddFontClick,
+                onRemoveFontClick = actions.onRemoveFontClick
+            )
+        }
+    }
 }
 
 @Composable
-fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions, editingEmoji: EmojiDetection?) {
+fun LargeScreenLayout(
+    state: EditScreenState,
+    actions: EditScreenActions,
+    editingEmoji: EmojiDetection?,
+    showSettingsSheet: Boolean,
+    onDismissSettingsSheet: () -> Unit
+) {
 //    Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainer // Consistent background
 //    ) { innerPadding -> // Scaffold provides padding, respect it if needed, though NavSuite might handle it
 //        NavigationSuiteScaffold(
@@ -288,11 +335,12 @@ fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions, editin
 //            }
 //        }
 //    }
+    val isDrawerOpenRequest = editingEmoji != null || showSettingsSheet
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
     // 2. 使用 LaunchedEffect 同步 ViewModel 状态 和 SideSheet 状态
-    LaunchedEffect(editingEmoji) {
-        if (editingEmoji != null) {
+    LaunchedEffect(isDrawerOpenRequest) {
+        if (isDrawerOpenRequest) {
             drawerState.open()
         } else {
             drawerState.close()
@@ -301,9 +349,12 @@ fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions, editin
 
     // 3. 监听 SideSheet 的关闭事件 (比如点击外部)，并通知 ViewModel
     LaunchedEffect(drawerState.currentValue) {
-        // 如果用户关闭了抽屉，但 ViewModel 的状态仍然是“正在编辑”，则调用取消操作
-        if (drawerState.currentValue == DrawerValue.Closed && editingEmoji != null) {
-            actions.onCancelEditing()
+        if (drawerState.currentValue == DrawerValue.Closed && isDrawerOpenRequest) {
+            if (editingEmoji != null) {
+                actions.onCancelEditing()
+            } else {
+                onDismissSettingsSheet()
+            }
         }
     }
 
@@ -311,28 +362,49 @@ fun LargeScreenLayout(state: EditScreenState, actions: EditScreenActions, editin
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
         ModalNavigationDrawer(
             drawerState = drawerState,
-            gesturesEnabled = editingEmoji != null, // 仅在编辑时允许手势
+            gesturesEnabled = isDrawerOpenRequest, // 抽屉打开时才允许手势
             drawerContent = {
-                // 在抽屉内容内部，将布局方向恢复为从左到右 (LTR)，以免影响内容本身
                 CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-                    ModalDrawerSheet(
-                        modifier = Modifier.width(360.dp) // 设置 SideSheet 的宽度
+                    ModalDrawerSheet (
+                        drawerContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest
                     ) {
-                        if (editingEmoji != null) {
-                            val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
-                            // 再次复用完全相同的 EditEmojiBottomSheetContent
-                            EditEmojiSideSheetContent(
-                                initialEmoji = editingEmoji.emoji,
-                                initialDiameter = editingEmoji.diameter,
-                                initialRotation = editingEmoji.angle,
-                                availableEmojis = state.predefinedEmojiList ?: emptyList(),
-                                fontFamily = state.fontFamily,
-                                onConfirm = actions.onConfirmEditing,
-                                onDismiss = actions.onCancelEditing,
-                                maxDiameter = maxDiameter,
-                                onValueChange = actions.onEditingValueChanged
-                            )
-                        }
+                            // 动态切换抽屉内容
+                            if (editingEmoji != null) {
+                                // --- 显示 Emoji 编辑器 ---
+                                val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
+                                EditEmojiSideSheetContent (
+                                    initialEmoji = editingEmoji.emoji,
+                                    initialDiameter = editingEmoji.diameter,
+                                    initialRotation = editingEmoji.angle,
+                                    availableEmojis = state.predefinedEmojiList ?: emptyList(),
+                                    fontFamily = state.fontFamily,
+                                    onConfirm = actions.onConfirmEditing,
+                                    onDismiss = actions.onCancelEditing,
+                                    maxDiameter = maxDiameter,
+                                    onValueChange = actions.onEditingValueChanged
+                                )
+                            } else if (showSettingsSheet) {
+                                // --- 显示设置面板 ---
+                                var isEditingEmojiListInSheet by remember { mutableStateOf(false) }
+                                SettingsSideSheetContent (
+                                    emojiOptions = state.predefinedEmojiList ?: emptyList(),
+                                    isEditingEmojiList = isEditingEmojiListInSheet,
+                                    fontFamily = state.fontFamily,
+                                    isAppIconHidden = state.isAppIconHidden,
+                                    availableFontNames = state.availableFontNames ?: emptyList(),
+                                    selectedFontIndex = state.selectedFontIndex,
+                                    onEditClick = { isEditingEmojiListInSheet = true },
+                                    onEditConfirm = { newEmojiList ->
+                                        actions.onPredefinedEmojisEdited(newEmojiList)
+                                        isEditingEmojiListInSheet = false
+                                    },
+                                    onHideIconToggle = actions.onHideIconToggle,
+                                    onFontSelected = actions.onFontSelected,
+                                    onAddFontClick = actions.onAddFontClick,
+                                    onRemoveFontClick = actions.onRemoveFontClick
+                                )
+                            }
+
                     }
                 }
             }

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
@@ -170,7 +171,12 @@ fun CompactScreenLayout(
         }
     }
     if (editingEmoji != null) {
-        val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val bottomSheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            // 只阻止用户将其关闭 (变为 Hidden)
+            confirmValueChange = { it != SheetValue.Hidden }
+        )
+
         val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
 
         ModalBottomSheet(
@@ -248,8 +254,8 @@ fun LargeScreenLayout(
     SideSheet(
         showSheet = showSideSheet,
         onDismissSheet = onDismiss,
+        isModal = (editingEmoji == null), // 编辑 emoji 时为 false，其他情况(设置)为 true
         sheetContent = {
-            // 调用新的内容 Composable
             SideSheetContent(
                 state = state,
                 actions = actions,

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
@@ -132,9 +132,6 @@ class EmojiViewModel @Inject constructor(
                         loadedTypeface = typeface      // <--- 更新原生字体
                     )
                 }
-                if (needsRerender) {
-                    rerenderBitmap()
-                }
             }
         }
     }
@@ -150,12 +147,14 @@ class EmojiViewModel @Inject constructor(
             // Reset relevant parts of the state, keep settings
             it.copy(
                 originalBitmap = null,
-                processedBitmap = null,
+                processedBitmap = null, // 同时清除 processedBitmap
                 selectedEmojis = emptyList(),
                 isProcessing = false,
                 isRendering = false,
                 errorMessage = null,
-                successMessage = null
+                successMessage = null,
+                editingEmoji = null,
+                editingEmojiIndex = null
             )
         }
     }
@@ -205,6 +204,23 @@ class EmojiViewModel @Inject constructor(
         }
     }
 
+    /**
+     * 关键修改：创建一个按需渲染最终 Bitmap 的挂起函数
+     */
+    private suspend fun renderFinalBitmap(): Bitmap? {
+        val base = _uiState.value.originalBitmap ?: return null
+        val emojis = _uiState.value.selectedEmojis
+        val font = _uiState.value.selectedFontPath
+
+        _uiState.update { it.copy(isRendering = true) }
+
+        val result = renderEmojiOnBitmapUseCase(base, emojis, font)
+
+        _uiState.update { it.copy(isRendering = false) }
+
+        return result.getOrNull()
+    }
+
     // Private helper for detect flow
     private fun renderInitialBitmap(baseBitmap: Bitmap, emojiDetections: List<EmojiDetection>) {
         viewModelScope.launch {
@@ -230,10 +246,15 @@ class EmojiViewModel @Inject constructor(
      * Shares the processed image.
      * (Signature matches original, but bitmap parameter is ignored)
      */
-    fun shareImage() { // Keep signature, but use state's bitmap
-        val processedBitmap = _uiState.value.processedBitmap ?: return
+    fun shareImage() {
         viewModelScope.launch {
-            generateShareableUriUseCase(processedBitmap).fold(
+            val finalBitmap = renderFinalBitmap()
+            if (finalBitmap == null) {
+                _shareEvent.emit(ShareEvent.Error("Failed to render final image for sharing.", Constants.STATUS_SHARE))
+                return@launch
+            }
+
+            generateShareableUriUseCase(finalBitmap).fold(
                 onSuccess = { uri ->
                     _shareEvent.emit(ShareEvent.ShareImage(uri))
                 },
@@ -249,12 +270,16 @@ class EmojiViewModel @Inject constructor(
      * Saves the processed image to the gallery.
      * (Signature matches original, but bitmap parameter is ignored)
      */
-    fun saveImageToGallery() { // Keep signature, but use state's bitmap
-        val processedBitmap = _uiState.value.processedBitmap ?: return
+    fun saveImageToGallery() {
         viewModelScope.launch {
-            saveImageUseCase(processedBitmap).fold(
+            val finalBitmap = renderFinalBitmap()
+            if (finalBitmap == null) {
+                _shareEvent.emit(ShareEvent.Error("Failed to render final image for saving.", Constants.STATUS_SAVE))
+                return@launch
+            }
+
+            saveImageUseCase(finalBitmap).fold(
                 onSuccess = {
-                    // Use event for Toast/Snackbar feedback in UI
                     _shareEvent.emit(ShareEvent.Success(Constants.STATUS_SAVE))
                 },
                 onFailure = { exception ->
@@ -306,22 +331,15 @@ class EmojiViewModel @Inject constructor(
             _uiState.update { it.copy(errorMessage = "Cannot add emoji without an image.") }
             return
         }
-        val currentList = _uiState.value.selectedEmojis.toMutableList()
+        // 1. 创建新的 Emoji 检测对象
         val newDetection = EmojiDetection(xCenter = x, yCenter = y, diameter = diameter, angle = angle, emoji = emoji)
-        currentList.add(newDetection)
 
-        // 先更新状态，将新的 emoji 加入列表
-        _uiState.update { it.copy(selectedEmojis = currentList) }
-
-        // 如果需要立即编辑
-        if (startEditing) {
-            // 新添加的 emoji 位于列表的末尾
-            val newIndex = currentList.lastIndex
-            // 调用 startEditing，UI 将自动弹出底部编辑窗口
-            startEditing(newIndex)
-        } else {
-            // 如果不需要立即编辑（保留旧逻辑路径），则直接重绘
-            rerenderBitmap()
+        // 2. 不将其添加到主列表，而是直接放入瞬时编辑状态
+        _uiState.update {
+            it.copy(
+                editingEmoji = newDetection,
+                editingEmojiIndex = -1 // 使用 -1 来标记这是一个“添加”操作，而非“编辑”
+            )
         }
     }
 
@@ -350,20 +368,27 @@ class EmojiViewModel @Inject constructor(
             angle = angle ?: currentEditing.angle
         )
         _uiState.update { it.copy(editingEmoji = updatedEmoji) }
-//        editingStateFlow.value = updatedEmoji // 触发 flow
     }
 
     /**
      * 用户点击"确定"，确认修改
      */
     fun confirmEditing() {
-        val status = _uiState.value.editingEmoji ?: return
-        val index = _uiState.value.editingEmojiIndex ?: return
+        val transientEmoji = _uiState.value.editingEmoji ?: return
+        val transientIndex = _uiState.value.editingEmojiIndex
         val currentList = _uiState.value.selectedEmojis.toMutableList()
-        currentList[index] = status
+
+        if (transientIndex != null && transientIndex == -1) {
+            // 情况2：这是一个新的 Emoji，现在将它添加到主列表中
+            currentList.add(transientEmoji)
+        } else if (transientIndex != null && transientIndex >= 0 && transientIndex < currentList.size) {
+            // 情况1：这是一个已存在的 Emoji，更新它
+            currentList[transientIndex] = transientEmoji
+        }
+
+        // 清除瞬时编辑状态
         _uiState.update { it.copy(selectedEmojis = currentList, editingEmoji = null, editingEmojiIndex = null) }
         editingStateFlow.value = null
-        rerenderBitmap() // 使用最终确认的值进行一次最终的重绘
     }
 
     /**
@@ -372,7 +397,6 @@ class EmojiViewModel @Inject constructor(
     fun cancelEditing() {
         _uiState.update { it.copy(editingEmoji = null, editingEmojiIndex = null) }
         editingStateFlow.value = null
-        rerenderBitmap() // 恢复到编辑前的状态
     }
 
     /**

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import top.maary.emojiface.datastore.PreferenceRepository
@@ -46,9 +48,12 @@ data class EditUiState(
     val isProcessing: Boolean = false, // For background tasks like detection/initial render
     val isRendering: Boolean = false, // Specific for re-rendering after updates
     val errorMessage: String? = null,
-    val successMessage: String? = null // Optional for short success feedback
+    val successMessage: String? = null, // Optional for short success feedback
+    val editingEmojiIndex: Int? = null, // 正在编辑的 emoji 的索引
+    val editingEmoji: EmojiDetection? = null, // 正在编辑的 emoji 的瞬时数据
 )
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class EmojiViewModel @Inject constructor(
     private val preferenceRepository: PreferenceRepository, // Keep for observing flows
@@ -72,9 +77,21 @@ class EmojiViewModel @Inject constructor(
     private val _shareEvent = MutableSharedFlow<ShareEvent>()
     val shareEvent: SharedFlow<ShareEvent> = _shareEvent.asSharedFlow()
 
+    private val editingStateFlow = MutableStateFlow<EmojiDetection?>(null)
+
     init {
         // Observe preferences and update state
         observePreferences()
+        viewModelScope.launch {
+            editingStateFlow
+                .debounce(50L) // 防抖，用户停止滑动50毫秒后再触发
+                .collect { emoji ->
+                    if (emoji != null) {
+                        // 当有稳定的编辑中状态时，触发重绘
+                        rerenderWithTransientEdit()
+                    }
+                }
+        }
     }
 
     private fun observePreferences() {
@@ -274,7 +291,7 @@ class EmojiViewModel @Inject constructor(
      * Adds a new emoji at the specified coordinates.
      * (Signature matches original)
      */
-    fun addEmoji(x: Float, y: Float, emoji: String, diameter: Float, angle: Float) {
+    fun addEmoji(x: Float, y: Float, emoji: String, diameter: Float, angle: Float, startEditing: Boolean = false) {
         if (_uiState.value.originalBitmap == null) {
             _uiState.update { it.copy(errorMessage = "Cannot add emoji without an image.") }
             return
@@ -283,8 +300,101 @@ class EmojiViewModel @Inject constructor(
         val newDetection = EmojiDetection(xCenter = x, yCenter = y, diameter = diameter, angle = angle, emoji = emoji)
         currentList.add(newDetection)
 
+        // 先更新状态，将新的 emoji 加入列表
         _uiState.update { it.copy(selectedEmojis = currentList) }
-        rerenderBitmap() // Re-render after adding
+
+        // 如果需要立即编辑
+        if (startEditing) {
+            // 新添加的 emoji 位于列表的末尾
+            val newIndex = currentList.lastIndex
+            // 调用 startEditing，UI 将自动弹出底部编辑窗口
+            startEditing(newIndex)
+        } else {
+            // 如果不需要立即编辑（保留旧逻辑路径），则直接重绘
+            rerenderBitmap()
+        }
+    }
+
+    /**
+     * 开始编辑一个 Emoji
+     */
+    fun startEditing(index: Int) {
+        val emojiToEdit = _uiState.value.selectedEmojis.getOrNull(index)?.copy() ?: return
+        _uiState.update {
+            it.copy(
+                editingEmojiIndex = index,
+                editingEmoji = emojiToEdit
+            )
+        }
+        editingStateFlow.value = emojiToEdit // 触发 flow
+    }
+
+    /**
+     * 当滑块或输入框变化时，实时更新瞬时状态
+     */
+    fun updateEditingEmoji(emoji: String? = null, diameter: Float? = null, angle: Float? = null) {
+        val currentEditing = _uiState.value.editingEmoji ?: return
+        val updatedEmoji = currentEditing.copy(
+            emoji = emoji ?: currentEditing.emoji,
+            diameter = diameter ?: currentEditing.diameter,
+            angle = angle ?: currentEditing.angle
+        )
+        _uiState.update { it.copy(editingEmoji = updatedEmoji) }
+        editingStateFlow.value = updatedEmoji // 触发 flow
+    }
+
+    /**
+     * 用户点击"确定"，确认修改
+     */
+    fun confirmEditing() {
+        val status = _uiState.value.editingEmoji ?: return
+        val index = _uiState.value.editingEmojiIndex ?: return
+        val currentList = _uiState.value.selectedEmojis.toMutableList()
+        currentList[index] = status
+        _uiState.update { it.copy(selectedEmojis = currentList, editingEmoji = null, editingEmojiIndex = null) }
+        editingStateFlow.value = null
+        rerenderBitmap() // 使用最终确认的值进行一次最终的重绘
+    }
+
+    /**
+     * 用户取消编辑
+     */
+    fun cancelEditing() {
+        _uiState.update { it.copy(editingEmoji = null, editingEmojiIndex = null) }
+        editingStateFlow.value = null
+        rerenderBitmap() // 恢复到编辑前的状态
+    }
+
+    /**
+     * 私有的重绘方法，用于实时预览
+     */
+    private fun rerenderWithTransientEdit() {
+        val base = _uiState.value.originalBitmap ?: return
+        val emojis = _uiState.value.selectedEmojis.toMutableList()
+        val editingEmoji = _uiState.value.editingEmoji
+        val editingIndex = _uiState.value.editingEmojiIndex
+
+        if (editingEmoji != null && editingIndex != null && editingIndex in emojis.indices) {
+            emojis[editingIndex] = editingEmoji // 将正在编辑的 emoji 替换到列表中用于预览
+        } else {
+            return // 如果没有正在编辑的对象，则不重绘
+        }
+
+        val font = _uiState.value.selectedFontPath
+
+        // ... 接续 rerenderBitmap 的原有逻辑，但使用上面构造的临时 emojis 列表
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRendering = true) }
+            renderEmojiOnBitmapUseCase(base, emojis, font).fold(
+                onSuccess = { newBitmap ->
+                    _uiState.update { it.copy(processedBitmap = newBitmap, isRendering = false, errorMessage = null) }
+                },
+                onFailure = { exception ->
+                    _uiState.update { it.copy(isRendering = false, errorMessage = "Re-rendering failed: ${exception.localizedMessage}") }
+                }
+                // ... success/failure handling
+            )
+        }
     }
 
     // --- Settings Related ---

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
@@ -2,6 +2,7 @@ package top.maary.emojiface.ui.edit // Or your chosen package
 
 // Imports for Android, Lifecycle, Coroutines, Hilt, Flows, Graphics etc.
 import android.graphics.Bitmap
+import android.graphics.Typeface
 import android.net.Uri
 import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.ViewModel
@@ -15,7 +16,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import top.maary.emojiface.datastore.PreferenceRepository
@@ -32,6 +32,7 @@ import top.maary.emojiface.domain.usecase.UpdateEmojiOptionsUseCase
 import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.ShareEvent
 import top.maary.emojiface.util.Constants
+import top.maary.emojiface.util.getTypeFaceFromPath
 import top.maary.emojiface.util.loadFontFromPath
 import javax.inject.Inject
 
@@ -45,6 +46,7 @@ data class EditUiState(
     val availableFontPaths: List<String> = listOf(Constants.DEFAULT_FONT_MARKER),
     val selectedFontPath: String = Constants.DEFAULT_FONT_MARKER,
     val loadedFontFamily: FontFamily? = null,
+    val loadedTypeface: Typeface? = null, // <--- 新增原生 Typeface 状态
     val isProcessing: Boolean = false, // For background tasks like detection/initial render
     val isRendering: Boolean = false, // Specific for re-rendering after updates
     val errorMessage: String? = null,
@@ -82,16 +84,16 @@ class EmojiViewModel @Inject constructor(
     init {
         // Observe preferences and update state
         observePreferences()
-        viewModelScope.launch {
-            editingStateFlow
-                .debounce(50L) // 防抖，用户停止滑动50毫秒后再触发
-                .collect { emoji ->
-                    if (emoji != null) {
-                        // 当有稳定的编辑中状态时，触发重绘
-                        rerenderWithTransientEdit()
-                    }
-                }
-        }
+//        viewModelScope.launch {
+//            editingStateFlow
+//                .debounce(50L) // 防抖，用户停止滑动50毫秒后再触发
+//                .collect { emoji ->
+//                    if (emoji != null) {
+//                        // 当有稳定的编辑中状态时，触发重绘
+//                        rerenderWithTransientEdit()
+//                    }
+//                }
+//        }
     }
 
     private fun observePreferences() {
@@ -110,18 +112,26 @@ class EmojiViewModel @Inject constructor(
                 preferenceRepository.fontsList,
                 preferenceRepository.selectedFont
             ) { paths, selectedPath ->
-                val fontFamily = loadFontFromPath(selectedPath) // Load font reactively
-                Triple(paths, selectedPath, fontFamily)
-            }.collect { (paths, selectedPath, fontFamily) ->
+                // 同时加载两种字体对象
+                val fontFamily = loadFontFromPath(selectedPath)
+                val typeface = if (selectedPath == Constants.DEFAULT_FONT_MARKER) {
+                    Typeface.DEFAULT
+                } else {
+                    getTypeFaceFromPath(selectedPath)
+                }
+                // 将所有状态打包
+                Triple(paths, selectedPath, Pair(fontFamily, typeface))
+            }.collect { (paths, selectedPath, fontPair) ->
+                val (fontFamily, typeface) = fontPair
                 val needsRerender = _uiState.value.selectedFontPath != selectedPath && _uiState.value.originalBitmap != null
                 _uiState.update { currentState ->
                     currentState.copy(
                         availableFontPaths = paths,
                         selectedFontPath = selectedPath,
-                        loadedFontFamily = fontFamily
+                        loadedFontFamily = fontFamily, // 更新 Compose 字体
+                        loadedTypeface = typeface      // <--- 更新原生字体
                     )
                 }
-                // If font changed and image exists, trigger re-render
                 if (needsRerender) {
                     rerenderBitmap()
                 }
@@ -340,7 +350,7 @@ class EmojiViewModel @Inject constructor(
             angle = angle ?: currentEditing.angle
         )
         _uiState.update { it.copy(editingEmoji = updatedEmoji) }
-        editingStateFlow.value = updatedEmoji // 触发 flow
+//        editingStateFlow.value = updatedEmoji // 触发 flow
     }
 
     /**

--- a/app/src/main/java/top/maary/emojiface/ui/edit/model/EmojiDetection.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/model/EmojiDetection.kt
@@ -5,5 +5,5 @@ data class EmojiDetection(
     val yCenter: Float,
     val diameter: Float,
     val angle: Float,
-    var emoji: String
+    val emoji: String
 )

--- a/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenActions.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenActions.kt
@@ -33,12 +33,13 @@ data class EditScreenActions(
     /** 當使用者點擊「設定」按鈕時呼叫 (通常用於打開底部工作表)。 */
     val onSettingsClick: () -> Unit,
 
-    // --- 編輯/新增表情符號對話框操作 ---
-    /** 當編輯/新增對話框確認時呼叫，傳遞使用者輸入的值。*/
-    // 注意：內部邏輯會根據之前是點擊了現有卡片還是點擊了圖片來決定是更新還是新增。
-    val onEditDialogConfirm: (newEmoji: String, newDiameter: Float, newRotation: Float) -> Unit,
-    /** 當編輯/新增對話框被關閉時呼叫。 */
-    val onEditDialogDismiss: () -> Unit,
+    // --- 实时编辑表情符號操作 (替换原有 Dialog 操作) ---
+    /** 当用户在实时编辑时，参数发生了变化 */
+    val onEditingValueChanged: (emoji: String? , diameter: Float?, rotation: Float?) -> Unit,
+    /** 当用户确认实时编辑的结果时调用 */
+    val onConfirmEditing: () -> Unit,
+    /** 当用户取消实时编辑时调用 */
+    val onCancelEditing: () -> Unit,
 
     // --- 設定底部工作表操作 ---
     /** 當設定底部工作表被關閉時呼叫。 */

--- a/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenState.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenState.kt
@@ -1,5 +1,6 @@
 package top.maary.emojiface.ui.edit.state
 
+import android.graphics.Typeface
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.IntSize
@@ -28,6 +29,7 @@ data class EditScreenState(
     val emojiDetections: List<EmojiDetection>,
     val predefinedEmojiList: List<String>?,
     val fontFamily: FontFamily?,
+    val typeface: Typeface?,
     val isAddMode: Boolean,
     val isProcessing: Boolean, // 或者 isAnimating，用於控制 GlowingCard 動畫
     val imageContainerSize: IntSize,

--- a/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenState.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenState.kt
@@ -36,5 +36,6 @@ data class EditScreenState(
     val isAppIconHidden: Boolean,
     val availableFontNames: List<String>?, // 從 fontList (路徑) 映射過來的顯示名稱
     val selectedFontIndex: Int, // 當前選中字體在列表中的索引，方便 Dropdown 使用
-    val isMediumLayout: Boolean
+    val isMediumLayout: Boolean,
+    val editingEmojiIndex: Int?
 )


### PR DESCRIPTION
### Summary

This pull request introduces a major overhaul of the emoji editing experience, replacing the previous modal dialog with a real-time, non-blocking UI. Users can now see their changes to emoji size, rotation, and content instantly on the image canvas.

Additionally, this PR introduces two APK build variants (`default` and `icon-disabled`) to give users more control over the app's visibility in their launcher. The CI/CD pipeline has been updated accordingly to build and release these new variants.

### Detailed Changes

* **Real-Time Emoji Editing** #14 
    * Removed the modal `EditEmojiDialog` and its associated state management. 
    * Introduced a new `EmojiOverlay` Composable that draws emojis directly onto a `Canvas` on top of the image, providing immediate visual feedback for edits. 
    * The `ViewModel` no longer re-renders the entire bitmap for every change. Instead, it manages a transient editing state (`editingEmoji`) and generates the final bitmap only when saving or sharing. 
    * Added new actions (`onEditingValueChanged`, `onConfirmEditing`, `onCancelEditing`) to manage the real-time editing lifecycle. 
    * Tapping an existing emoji or adding a new one now enters a persistent editing mode. 

* **APK Build Variants & CI/CD**
    * Added `default` and `icon-disabled` product flavors using `flavorDimensions` in `build.gradle.kts`. 
        * The `default` variant shows the app icon by default. 
        * The `icon-disabled` variant hides the app icon by default, ideal for users who primarily use the app via the "Share" menu. 
    * The `AndroidManifest.xml` now uses a manifest placeholder (`mainActivityEnabled`) to control the launcher activity's visibility based on the selected flavor. 
    * The `README.md` file has been updated to explain the new variants to users. 
    * GitHub Actions workflows (`main.yml`, `commit.yml`) are updated to build, name, and upload all new APK variants as artifacts and release assets. 

* **Responsive UI Refactoring**
    * On compact screens, editing controls are now presented in a `ModalBottomSheet`. 
    * On medium and expanded screens, a new reusable `SideSheet` component has been implemented to host editing and settings controls, providing a non-modal experience that doesn't block the main content. 
    * The layout logic in `EditScreenLayout.kt` and `EditScreenContentInternal.kt` has been refactored to support the new editing state and direct the user to the appropriate bottom sheet or side sheet. 

* **ViewModel and State Management**
    * The `EmojiViewModel` now holds a native `Typeface` object in its state to facilitate efficient rendering on the `Canvas`. 
    * The `EditUiState` and `EditScreenState` have been updated to remove the dependency on a pre-rendered `processedBitmap` for the main display, now showing the `originalBitmap` with the `EmojiOverlay`. 
    * State management for the editing lifecycle is now centralized in the `EmojiViewModel` with methods like `startEditing`, `updateEditingEmoji`, `confirmEditing`, and `cancelEditing`. 
