### PR TITLE
[hotfix](ui): Adjust edit screen colors and bottom sheet behavior

### DIFF
--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -397,7 +397,7 @@ fun SliderWithCaption(
         horizontalAlignment = Alignment.CenterHorizontally) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             leadingIcon()
-            Text(text = description, fontSize = 14.sp)
+            Text(text = description, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface)
         }
 
         Slider(
@@ -617,6 +617,7 @@ fun EditEmojiBottomSheetContent(
                 leadingIcon = {
                     Icon(imageVector = Icons.Outlined.FormatSize,
                         contentDescription = stringResource(R.string.emoji_size),
+                        tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier
                             .padding(8.dp)
                             .size(16.dp))
@@ -635,6 +636,7 @@ fun EditEmojiBottomSheetContent(
                 leadingIcon = {
                     Icon(imageVector = Icons.Outlined.Rotate90DegreesCw,
                         contentDescription = stringResource(R.string.emoji_angle),
+                        tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier
                             .padding(8.dp)
                             .size(16.dp))

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
@@ -40,12 +39,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import top.maary.emojiface.R
 import top.maary.emojiface.ui.components.ActionRow
 import top.maary.emojiface.ui.components.DisplayPane
@@ -174,15 +175,22 @@ fun CompactScreenLayout(
         val bottomSheetState = rememberModalBottomSheetState(
             skipPartiallyExpanded = true,
             // 只阻止用户将其关闭 (变为 Hidden)
-            confirmValueChange = { it != SheetValue.Hidden }
+//            confirmValueChange = { it != SheetValue.Hidden }
         )
+        val scope = rememberCoroutineScope()
 
         val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
 
         ModalBottomSheet(
-            onDismissRequest = actions.onCancelEditing,
+            onDismissRequest = {
+                scope.launch {
+                    // 重新展开，以阻止关闭
+                    bottomSheetState.show()
+                }
+            },
             sheetState = bottomSheetState,
             dragHandle = { },
+            sheetGesturesEnabled = false,
             containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
         ) {
             // 完全复用现有的 Composable


### PR DESCRIPTION
### Summary

This pull request introduces two key improvements to the editing screen's UI. Firstly, it fixes an issue where certain UI elements, such as icons and text, did not correctly adapt to the application's theme, causing visibility problems in dark mode. Secondly, it modifies the behavior of the modal bottom sheet containing the editing controls to prevent it from being accidentally dismissed by the user.

### Detailed Changes

* **Theming and Color Correction:**
    * Explicitly set the `color` of the descriptive text in `SliderWithCaption` to `MaterialTheme.colorScheme.onSurface` to ensure it respects the current theme. 
    * Applied a `tint` of `MaterialTheme.colorScheme.onSurface` to the size and angle icons within the `EditEmojiBottomSheetContent` to guarantee their visibility across different themes. 

* **Modal Bottom Sheet Behavior:**
    * The `ModalBottomSheet` on the compact edit screen is now non-dismissible via user gestures.
    * Swipe-to-dismiss functionality has been disabled by setting `sheetGesturesEnabled = false`. 
    * The `onDismissRequest` lambda (triggered by tapping the scrim) has been updated to immediately `show()` the sheet again, preventing it from closing. 
    * The drag handle has been hidden by passing an empty composable to the `dragHandle` parameter. 
    * The previous `confirmValueChange` logic, which is buggy, has been removed.