### PR TITLE
[feat]: Implement long-press to delete and enhance UI interactivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         minSdk = 30
         targetSdk = 35
         versionCode = 2
-        versionName = "2025.06.21"
+        versionName = "2025.06.22"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/top/maary/emojiface/ui/components/DrawerSideSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/DrawerSideSheet.kt
@@ -1,5 +1,6 @@
 package top.maary.emojiface.ui.components
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
@@ -14,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
@@ -27,7 +29,7 @@ import top.maary.emojiface.ui.edit.state.EditScreenState
  * @param content 主屏幕内容。
  */
 @Composable
-fun SideSheet(
+fun DrawerSideSheet(
     showSheet: Boolean,
     onDismissSheet: () -> Unit,
     isModal: Boolean = true,
@@ -59,6 +61,7 @@ fun SideSheet(
             drawerContent = {
                 CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
                     ModalDrawerSheet(
+                        windowInsets = WindowInsets(0.dp),
                         drawerContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest
                     ) {
                         // 直接渲染传入的 sheetContent

--- a/app/src/main/java/top/maary/emojiface/ui/components/DrawerSideSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/DrawerSideSheet.kt
@@ -83,7 +83,8 @@ fun SideSheetContent(
     state: EditScreenState,
     actions: EditScreenActions,
     editingEmoji: EmojiDetection?,
-    showSettingsSheet: Boolean
+    showSettingsSheet: Boolean,
+    onSlidingStateChange: (Boolean) -> Unit
 ) {
     if (editingEmoji != null) {
         val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
@@ -96,7 +97,8 @@ fun SideSheetContent(
             onConfirm = actions.onConfirmEditing,
             onDismiss = actions.onCancelEditing,
             maxDiameter = maxDiameter,
-            onValueChange = actions.onEditingValueChanged
+            onValueChange = actions.onEditingValueChanged,
+            onSlidingStateChange = onSlidingStateChange
         )
     } else if (showSettingsSheet) {
         var isEditingEmojiListInSheet by remember { mutableStateOf(false) }

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -142,6 +142,7 @@ fun SettingsButton(backgroundColor: Color, onClick: () -> Unit) {
 @Composable
 fun EmojiCard(emoji: String,
               onClick: () -> Unit,
+              onLongClick: () -> Unit = {},
               clickable: Boolean = true,
               fontFamily: FontFamily? = null,
               containerColor: Color,
@@ -153,7 +154,14 @@ fun EmojiCard(emoji: String,
             .padding(horizontal = hPadding, vertical = vPadding)
             .clip(MaterialShapes.Cookie4Sided.toShape())
             .background(containerColor)
-            .clickable(enabled = clickable) { onClick() },  // 添加点击事件
+            .pointerInput(clickable) {
+                if (clickable) {
+                    detectTapGestures(
+                        onTap = { onClick() },
+                        onLongPress = { onLongClick() }
+                    )
+                }
+            },
     ) {
         Text(text = emoji, fontSize = 40.sp, fontFamily = fontFamily, modifier = Modifier
             .padding(8.dp)

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -16,13 +16,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -547,67 +550,68 @@ fun SettingsSideSheetContent(
     onAddFontClick: () -> Unit,
     onRemoveFontClick: (index: Int) -> Unit,
 ) {
-    Box(modifier = Modifier
-        .padding(horizontal = 8.dp, vertical = 2.dp)
-        .clip(
-            RoundedCornerShape(
-                topStart = 24.dp,
-                topEnd = 24.dp,
-                bottomStart = 4.dp,
-                bottomEnd = 4.dp
+    Column (modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)) {
+        Box(modifier = Modifier
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+            .clip(
+                RoundedCornerShape(
+                    topStart = 24.dp,
+                    topEnd = 24.dp,
+                    bottomStart = 4.dp,
+                    bottomEnd = 4.dp
+                )
             )
-        )
-        .background(MaterialTheme.colorScheme.surfaceContainerLow)){
-        Column {
-            Text(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 0.dp),
-                text = stringResource(R.string.emoji_list))
-            if (!isEditingEmojiList) {
-                PredefinedEmojiSettings(
-                    emojiOptions = emojiOptions,
-                    onClick = onEditClick,
-                    fontFamily = fontFamily)
-            } else {
-                EditEmojiList(
-                    emojiOptions = emojiOptions,
-                    onClick = onEditConfirm,
-                    fontFamily = fontFamily)
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)){
+            Column {
+                Text(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 0.dp),
+                    text = stringResource(R.string.emoji_list))
+                if (!isEditingEmojiList) {
+                    PredefinedEmojiSettings(
+                        emojiOptions = emojiOptions,
+                        onClick = onEditClick,
+                        fontFamily = fontFamily)
+                } else {
+                    EditEmojiList(
+                        emojiOptions = emojiOptions,
+                        onClick = onEditConfirm,
+                        fontFamily = fontFamily)
+                }
             }
         }
-    }
-    Box(modifier = Modifier
-        .padding(horizontal = 8.dp, vertical = 2.dp)
-        .clip(
-            RoundedCornerShape(
-                topStart = 4.dp,
-                topEnd = 4.dp,
-                bottomStart = 4.dp,
-                bottomEnd = 4.dp
+        Box(modifier = Modifier
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+            .clip(
+                RoundedCornerShape(
+                    topStart = 4.dp,
+                    topEnd = 4.dp,
+                    bottomStart = 4.dp,
+                    bottomEnd = 4.dp
+                )
             )
-        )
-        .background(MaterialTheme.colorScheme.surfaceContainerLow)){
-        HomeSwitchRow(state = isAppIconHidden, onCheckedChange = { onHideIconToggle(it) })
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)){
+            HomeSwitchRow(state = isAppIconHidden, onCheckedChange = { onHideIconToggle(it) })
 
-    }
+        }
 
-    Box(modifier = Modifier
-        .padding(horizontal = 8.dp, vertical = 2.dp)
-        .clip(
-            RoundedCornerShape(
-                topStart = 4.dp,
-                topEnd = 4.dp,
-                bottomStart = 24.dp,
-                bottomEnd = 24.dp
+        Box(modifier = Modifier
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+            .clip(
+                RoundedCornerShape(
+                    topStart = 4.dp,
+                    topEnd = 4.dp,
+                    bottomStart = 24.dp,
+                    bottomEnd = 24.dp
+                )
             )
-        )
-        .background(MaterialTheme.colorScheme.surfaceContainerLow)){
-        DropdownRow(
-            options = availableFontNames.toMutableList(),
-            position = selectedFontIndex,
-            onItemClicked = onFontSelected,
-            onAddClick = onAddFontClick,
-            onRemoveClick = { onRemoveFontClick(it) })
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)){
+            DropdownRow(
+                options = availableFontNames.toMutableList(),
+                position = selectedFontIndex,
+                onItemClicked = onFontSelected,
+                onAddClick = onAddFontClick,
+                onRemoveClick = { onRemoveFontClick(it) })
+        }
     }
-
 }
 
 @Composable
@@ -711,6 +715,7 @@ fun EditEmojiBottomSheetContent(
 
 @Composable
 fun EditEmojiSideSheetContent(
+    modifier: Modifier = Modifier,
     initialEmoji: String,
     initialDiameter: Float,
     initialRotation: Float,
@@ -723,9 +728,10 @@ fun EditEmojiSideSheetContent(
 ) {
 
     LazyColumn(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 16.dp)
+            .windowInsetsPadding(WindowInsets.safeDrawing),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         item {
@@ -852,7 +858,6 @@ fun EmojiOverlay(
     // 合并固定列表和正在编辑的临时状态，用于统一渲染
     val emojisToRender = remember(state.emojiDetections, editingEmoji) {
         val list = state.emojiDetections.toMutableList()
-//        val editingEmoji = editingEmoji
 
         if (editingEmoji != null) {
             val editingIndex = list.indexOfFirst { it.xCenter == editingEmoji.xCenter && it.yCenter == editingEmoji.yCenter }.takeIf { it != -1 }

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -2,11 +2,14 @@ package top.maary.emojiface.ui.components
 
 import android.graphics.Paint
 import android.graphics.Typeface
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -75,6 +78,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -130,10 +134,29 @@ fun SaveButtonCompact(backgroundColor: Color, onClick: () -> Unit) {
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SettingsButton(backgroundColor: Color, onClick: () -> Unit) {
-    FloatingActionButton(onClick = onClick,
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    // 根据按压状态，驱动一个缩放比例的动画
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.8f else 1.0f,
+        label = "SettingsButtonScaleAnimation"
+    )
+
+    FloatingActionButton(
+        onClick = onClick,
         containerColor = backgroundColor,
-        modifier = Modifier.padding(8.dp),
-        shape = MaterialShapes.Cookie7Sided.toShape()) {
+        // 使用 graphicsLayer 修饰符来应用缩放
+        modifier = Modifier
+            .padding(8.dp)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            },
+        interactionSource = interactionSource,
+        // 在这里，我们可以安全地使用原始的 Cookie7Sided 形状
+        shape = MaterialShapes.Cookie7Sided.toShape()
+    ) {
         Icon(Icons.Outlined.Settings, stringResource(R.string.settings))
     }
 }

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -180,7 +180,14 @@ fun EmojiCardSmall(emoji: String, onClick: () -> Unit, fontFamily: FontFamily? =
 }
 
 @Composable
-fun ResultImg(modifier: Modifier, bitmap: ImageBitmap, description: String, ratio: Float, animate: Boolean) {
+fun ResultImg(
+    modifier: Modifier,
+    bitmap: ImageBitmap,
+    description: String,
+    ratio: Float,
+    animate: Boolean,
+    imageModifier: Modifier = Modifier
+) {
     GlowingCard (
         modifier = modifier,
         ratio = ratio,
@@ -194,7 +201,10 @@ fun ResultImg(modifier: Modifier, bitmap: ImageBitmap, description: String, rati
                     .padding(horizontal = ratio * 8.dp, vertical = 8.dp)
                     .clip(
                         RoundedCornerShape(16.dp)
-                    ))
+                    )
+                    // 使用 .then() 连接外部传入的 Modifier
+                    .then(imageModifier)
+            )
         }
     )
 }
@@ -797,7 +807,6 @@ fun EmojiOverlay(
 ) {
     // 获取原始图片尺寸和屏幕上容器的尺寸，用于坐标和大小的缩放
     val originalWidth = state.currentImage?.width?.toFloat() ?: return
-    val originalHeight = state.currentImage.height.toFloat()
     val containerWidth = state.imageContainerSize.width.toFloat()
     val containerHeight = state.imageContainerSize.height.toFloat()
 
@@ -809,7 +818,7 @@ fun EmojiOverlay(
     // 合并固定列表和正在编辑的临时状态，用于统一渲染
     val emojisToRender = remember(state.emojiDetections, editingEmoji) {
         val list = state.emojiDetections.toMutableList()
-        val editingEmoji = editingEmoji
+//        val editingEmoji = editingEmoji
 
         if (editingEmoji != null) {
             val editingIndex = list.indexOfFirst { it.xCenter == editingEmoji.xCenter && it.yCenter == editingEmoji.yCenter }.takeIf { it != -1 }
@@ -882,7 +891,6 @@ fun DisplayPane(modifier: Modifier, state: EditScreenState, actions: EditScreenA
 
             val cornerRadius = 16.dp
             val verticalPadding = 8.dp
-            // 水平 padding 依赖于宽高比，与 ResultImg 内部逻辑保持一致
             val horizontalPadding = (state.aspectRatio ?: 1f) * 8f.dp
 
             // 准备一个用于覆盖层的 Box，它的大小将和图片容器一致
@@ -891,76 +899,69 @@ fun DisplayPane(modifier: Modifier, state: EditScreenState, actions: EditScreenA
                     .aspectRatio(state.aspectRatio ?: 1f)
                     .fillMaxSize()
             ) {
-                GlowingCard (
+
+                // 1. 将原先 Image 的特定逻辑提取到一个 Modifier 变量中
+                val imageSpecificModifier = Modifier
+                    .onGloballyPositioned { layoutCoordinates ->
+                        // 回報容器尺寸
+                        actions.onImageContainerMeasured(layoutCoordinates.size)
+                    }
+                    .then(
+                        if (state.isAddMode) {
+                            Modifier.pointerInput(Unit) { // 合并 pointerInput
+                                detectTapGestures { offset ->
+                                    val containerWidth = state.imageContainerSize.width
+                                    val containerHeight = state.imageContainerSize.height
+                                    val originalBitmapWidth = state.currentImage?.width
+                                        ?: state.displayedBitmap.width
+                                    val originalBitmapHeight = state.currentImage?.height
+                                        ?: state.displayedBitmap.height
+
+                                    if (containerWidth > 0 && containerHeight > 0) {
+                                        val scaleX =
+                                            originalBitmapWidth.toFloat() / containerWidth
+                                        val scaleY =
+                                            originalBitmapHeight.toFloat() / containerHeight
+                                        val originalX = offset.x * scaleX
+                                        val originalY = offset.y * scaleY
+                                        actions.onImageTapToAdd(
+                                            Offset(
+                                                originalX,
+                                                originalY
+                                            )
+                                        )
+                                    } else {
+                                        actions.onImageTapToAdd(offset)
+                                    }
+                                }
+                            }
+                        } else Modifier
+                    )
+
+                // 2. 使用重构后的 ResultImg
+                ResultImg(
                     modifier = Modifier
-                        .aspectRatio(state.aspectRatio ?: 1f) // 使用 state 中的寬高比
-                        .fillMaxSize(),
+                        .aspectRatio(state.aspectRatio ?: 1f)
+                        .fillMaxSize(), // GlowingCard 的 Modifier
+                    bitmap = state.displayedBitmap,
+                    description = stringResource(R.string.process_result),
                     ratio = state.aspectRatio ?: 1f,
                     animate = state.isProcessing,
-                    cornersRadius = 16.dp,
-                    content = {
-                        Image(bitmap = state.displayedBitmap,
-                            contentDescription = stringResource(R.string.process_result),
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(
-                                    horizontal = (state.aspectRatio ?: 1f) * 8.dp,
-                                    vertical = 8.dp
-                                )
-                                .clip(
-                                    RoundedCornerShape(16.dp)
-                                )
-                                .onGloballyPositioned { layoutCoordinates ->
-                                    // 回報容器尺寸
-                                    actions.onImageContainerMeasured(layoutCoordinates.size)
-                                }
-                                .then(
-                                    if (state.isAddMode) {
-                                    Modifier.pointerInput(Unit) { // 合并 pointerInput
-
-                                        detectTapGestures { offset ->
-                                            // ... (原有的 onImageTapToAdd 逻辑保持不变)
-                                            val containerWidth = state.imageContainerSize.width
-                                            val containerHeight = state.imageContainerSize.height
-                                            val originalBitmapWidth = state.currentImage?.width
-                                                ?: state.displayedBitmap.width
-                                            val originalBitmapHeight = state.currentImage?.height
-                                                ?: state.displayedBitmap.height
-
-                                            if (containerWidth > 0 && containerHeight > 0) {
-                                                val scaleX =
-                                                    originalBitmapWidth.toFloat() / containerWidth
-                                                val scaleY =
-                                                    originalBitmapHeight.toFloat() / containerHeight
-                                                val originalX = offset.x * scaleX
-                                                val originalY = offset.y * scaleY
-                                                actions.onImageTapToAdd(
-                                                    Offset(
-                                                        originalX,
-                                                        originalY
-                                                    )
-                                                )
-                                            } else {
-                                                actions.onImageTapToAdd(offset)
-                                            }
-                                        }
-
-                                    }
-                                } else Modifier
-                                ))
-                    }
+                    imageModifier = imageSpecificModifier // 3. 将提取的 Modifier 传入
                 )
 
-                EmojiOverlay(state = state, editingEmoji = editingEmoji,
+                EmojiOverlay(
+                    state = state,
+                    editingEmoji = editingEmoji,
                     padding = PaddingValues(horizontal = horizontalPadding, vertical = verticalPadding),
-                    cornerRadius = cornerRadius,)
-
+                    cornerRadius = cornerRadius,
+                )
             }
 
         } else {
-            // 沒有圖片時顯示選擇圖片按鈕
+            // 沒有圖片時顯示選擇圖片按鈕 (这部分逻辑不变)
             ExtendedFloatingActionButton(
-                onClick = actions.onPickImageClick, // 使用 action
+                onClick = actions.onPickImageClick,
                 icon = {
                     Icon(
                         Icons.Outlined.AddPhotoAlternate,

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -70,6 +71,7 @@ import androidx.compose.material3.TooltipDefaults.rememberTooltipPositionProvide
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -436,7 +438,8 @@ fun SliderWithCaption(
     value: Float,
     onValueChange: (Float) -> Unit,
     minRange: Float,
-    maxRange: Float
+    maxRange: Float,
+    interactionSource: MutableInteractionSource
 ) {
 
     Column(
@@ -453,7 +456,8 @@ fun SliderWithCaption(
             modifier = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
             value = value,
             onValueChange = onValueChange,
-            valueRange = minRange..maxRange
+            valueRange = minRange..maxRange,
+            interactionSource = interactionSource
         )
 
     }
@@ -632,8 +636,18 @@ fun EditEmojiBottomSheetContent(
     fontFamily: FontFamily?,
     onValueChange: (emoji: String?, diameter: Float?, rotation: Float?) -> Unit,
     onConfirm: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onSlidingStateChange: (Boolean) -> Unit
 ){
+    val sizeInteractionSource = remember { MutableInteractionSource() }
+    val angleInteractionSource = remember { MutableInteractionSource() }
+
+    val isSizeSliderDragged by sizeInteractionSource.collectIsDraggedAsState()
+    val isAngleSliderDragged by angleInteractionSource.collectIsDraggedAsState()
+
+    LaunchedEffect(isSizeSliderDragged, isAngleSliderDragged) {
+        onSlidingStateChange(isSizeSliderDragged || isAngleSliderDragged)
+    }
 
     Column (modifier = Modifier
         .fillMaxWidth()
@@ -682,7 +696,8 @@ fun EditEmojiBottomSheetContent(
                 value = initialDiameter,
                 onValueChange = { onValueChange(null, it, null) },
                 minRange = 20f,
-                maxRange = maxDiameter
+                maxRange = maxDiameter,
+                interactionSource = sizeInteractionSource
             )
 
             Spacer(modifier = Modifier.width(8.dp))
@@ -701,7 +716,8 @@ fun EditEmojiBottomSheetContent(
                 value = initialRotation,
                 onValueChange = { onValueChange(null, null, it) },
                 minRange = -90f,
-                maxRange = 90f
+                maxRange = 90f,
+                interactionSource = angleInteractionSource
             )
         }
 
@@ -732,8 +748,22 @@ fun EditEmojiSideSheetContent(
     fontFamily: FontFamily?,
     onValueChange: (emoji: String?, diameter: Float?, rotation: Float?) -> Unit,
     onConfirm: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onSlidingStateChange: (Boolean) -> Unit
 ) {
+
+    // 1. 为两个滑块创建 interactionSource
+    val sizeInteractionSource = remember { MutableInteractionSource() }
+    val angleInteractionSource = remember { MutableInteractionSource() }
+
+    // 2. 监测两个滑块的拖动状态
+    val isSizeSliderDragged by sizeInteractionSource.collectIsDraggedAsState()
+    val isAngleSliderDragged by angleInteractionSource.collectIsDraggedAsState()
+
+    // 3. 当任一滑块被拖动时，通过回调函数通知父组件
+    LaunchedEffect(isSizeSliderDragged, isAngleSliderDragged) {
+        onSlidingStateChange(isSizeSliderDragged || isAngleSliderDragged)
+    }
 
     LazyColumn(
         modifier = modifier
@@ -822,7 +852,8 @@ fun EditEmojiSideSheetContent(
                 value = initialDiameter,
                 onValueChange = { onValueChange(null, it, null) },
                 minRange = 20f,
-                maxRange = maxDiameter
+                maxRange = maxDiameter,
+                interactionSource = sizeInteractionSource
             )
         }
         item {
@@ -844,7 +875,8 @@ fun EditEmojiSideSheetContent(
                 value = initialRotation,
                 onValueChange = { onValueChange(null, null, it) },
                 minRange = -90f,
-                maxRange = 90f
+                maxRange = 90f,
+                interactionSource = angleInteractionSource
             )
         }
 

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -17,7 +17,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -25,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -89,6 +90,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.times
@@ -550,7 +552,11 @@ fun SettingsSideSheetContent(
     onAddFontClick: () -> Unit,
     onRemoveFontClick: (index: Int) -> Unit,
 ) {
-    Column (modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)) {
+    Column (modifier = Modifier.padding(
+        top = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding(),
+        end = WindowInsets.safeDrawing.asPaddingValues().calculateEndPadding(
+            layoutDirection = LayoutDirection.Ltr
+        ))) {
         Box(modifier = Modifier
             .padding(horizontal = 8.dp, vertical = 2.dp)
             .clip(
@@ -611,6 +617,8 @@ fun SettingsSideSheetContent(
                 onAddClick = onAddFontClick,
                 onRemoveClick = { onRemoveFontClick(it) })
         }
+
+        Spacer(Modifier.height(WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding()))
     }
 }
 
@@ -730,8 +738,12 @@ fun EditEmojiSideSheetContent(
     LazyColumn(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-            .windowInsetsPadding(WindowInsets.safeDrawing),
+            .padding(
+                top = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding(),
+                start = 16.dp,
+                end = WindowInsets.safeDrawing.asPaddingValues().calculateEndPadding(
+                    layoutDirection = LayoutDirection.Ltr
+                ) + 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         item {
@@ -834,6 +846,10 @@ fun EditEmojiSideSheetContent(
                 minRange = -90f,
                 maxRange = 90f
             )
+        }
+
+        item {
+            Spacer(Modifier.height(WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding()))
         }
     }
 }

--- a/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/EditScreenComponents.kt
@@ -140,15 +140,18 @@ fun SettingsButton(backgroundColor: Color, onClick: () -> Unit) {
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun EmojiCard(emoji: String,
-              onClick: () -> Unit,
-              onLongClick: () -> Unit = {},
-              clickable: Boolean = true,
-              fontFamily: FontFamily? = null,
-              containerColor: Color,
-              hPadding: Dp = 0.dp, vPadding: Dp = 16.dp) {
+fun EmojiCard(
+    emoji: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier, // 新增 Modifier 参数
+    onLongClick: () -> Unit = {},
+    clickable: Boolean = true,
+    fontFamily: FontFamily? = null,
+    containerColor: Color,
+    hPadding: Dp = 0.dp, vPadding: Dp = 16.dp
+) {
     Box(
-        modifier = Modifier
+        modifier = modifier // 应用传入的 Modifier
             .wrapContentHeight()
             .wrapContentWidth()
             .padding(horizontal = hPadding, vertical = vPadding)

--- a/app/src/main/java/top/maary/emojiface/ui/components/SideSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/SideSheet.kt
@@ -1,6 +1,5 @@
 package top.maary.emojiface.ui.components
 
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
@@ -83,39 +82,38 @@ fun SideSheetContent(
     editingEmoji: EmojiDetection?,
     showSettingsSheet: Boolean
 ) {
-    val scrollState = rememberScrollState()
-        if (editingEmoji != null) {
-            val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
-            EditEmojiSideSheetContent(
-                initialEmoji = editingEmoji.emoji,
-                initialDiameter = editingEmoji.diameter,
-                initialRotation = editingEmoji.angle,
-                availableEmojis = state.predefinedEmojiList ?: emptyList(),
-                fontFamily = state.fontFamily,
-                onConfirm = actions.onConfirmEditing,
-                onDismiss = actions.onCancelEditing,
-                maxDiameter = maxDiameter,
-                onValueChange = actions.onEditingValueChanged
-            )
-        } else if (showSettingsSheet) {
-            var isEditingEmojiListInSheet by remember { mutableStateOf(false) }
-            SettingsSideSheetContent(
-                emojiOptions = state.predefinedEmojiList ?: emptyList(),
-                isEditingEmojiList = isEditingEmojiListInSheet,
-                fontFamily = state.fontFamily,
-                isAppIconHidden = state.isAppIconHidden,
-                availableFontNames = state.availableFontNames ?: emptyList(),
-                selectedFontIndex = state.selectedFontIndex,
-                onEditClick = { isEditingEmojiListInSheet = true },
-                onEditConfirm = { newEmojiList ->
-                    actions.onPredefinedEmojisEdited(newEmojiList)
-                    isEditingEmojiListInSheet = false
-                },
-                onHideIconToggle = actions.onHideIconToggle,
-                onFontSelected = actions.onFontSelected,
-                onAddFontClick = actions.onAddFontClick,
-                onRemoveFontClick = actions.onRemoveFontClick
-            )
-        }
+    if (editingEmoji != null) {
+        val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
+        EditEmojiSideSheetContent(
+            initialEmoji = editingEmoji.emoji,
+            initialDiameter = editingEmoji.diameter,
+            initialRotation = editingEmoji.angle,
+            availableEmojis = state.predefinedEmojiList ?: emptyList(),
+            fontFamily = state.fontFamily,
+            onConfirm = actions.onConfirmEditing,
+            onDismiss = actions.onCancelEditing,
+            maxDiameter = maxDiameter,
+            onValueChange = actions.onEditingValueChanged
+        )
+    } else if (showSettingsSheet) {
+        var isEditingEmojiListInSheet by remember { mutableStateOf(false) }
+        SettingsSideSheetContent(
+            emojiOptions = state.predefinedEmojiList ?: emptyList(),
+            isEditingEmojiList = isEditingEmojiListInSheet,
+            fontFamily = state.fontFamily,
+            isAppIconHidden = state.isAppIconHidden,
+            availableFontNames = state.availableFontNames ?: emptyList(),
+            selectedFontIndex = state.selectedFontIndex,
+            onEditClick = { isEditingEmojiListInSheet = true },
+            onEditConfirm = { newEmojiList ->
+                actions.onPredefinedEmojisEdited(newEmojiList)
+                isEditingEmojiListInSheet = false
+            },
+            onHideIconToggle = actions.onHideIconToggle,
+            onFontSelected = actions.onFontSelected,
+            onAddFontClick = actions.onAddFontClick,
+            onRemoveFontClick = actions.onRemoveFontClick
+        )
+    }
 
 }

--- a/app/src/main/java/top/maary/emojiface/ui/components/SurfaceSideSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/SurfaceSideSheet.kt
@@ -1,0 +1,106 @@
+package top.maary.emojiface.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateIntOffsetAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SurfaceSideSheet(
+    showSheet: Boolean,
+    onDismissSheet: () -> Unit,
+    isModal: Boolean = true, // <-- 新增 isModal 参数，默认为 true
+    sheetContent: @Composable ColumnScope.() -> Unit,
+    content: @Composable () -> Unit
+) {
+    // 状态来驱动动画
+    var animationState by remember { mutableStateOf(showSheet) }
+    LaunchedEffect(showSheet) {
+        animationState = showSheet
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // 1. 主屏幕内容
+        content()
+
+        // 2. 遮罩层 (Scrim)
+        val scrimColor by animateColorAsState(
+            targetValue = if (animationState) Color.Black.copy(alpha = 0.32f) else Color.Transparent,
+            animationSpec = tween(),
+            label = "scrimColor"
+        )
+
+        if (scrimColor != Color.Transparent) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(scrimColor)
+                    // --- 修改部分 ---
+                    // 仅在 isModal 为 true 时，才允许通过点击关闭
+                    .then(if (isModal) {
+                        Modifier.pointerInput(Unit) {
+                            detectTapGestures { onDismissSheet() }
+                        }
+                    } else {
+                        Modifier
+                    })
+                // --- 修改结束 ---
+            )
+        }
+
+
+        // 3. 抽屉面板内容
+        val density = LocalDensity.current
+        val sheetWidth = 320.dp
+
+        val offset by animateIntOffsetAsState(
+            targetValue = if (animationState) {
+                IntOffset.Zero
+            } else {
+                IntOffset(with(density) { sheetWidth.toPx() }.toInt(), 0)
+            },
+            animationSpec = spring(stiffness = Spring.StiffnessMedium),
+            label = "sheetOffset"
+        )
+
+        Surface(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(sheetWidth)
+                .align(Alignment.CenterEnd)
+                .offset { offset }
+                .shadow(8.dp)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                sheetContent()
+            }
+        }
+    }
+}

--- a/app/src/main/java/top/maary/emojiface/ui/components/SurfaceSideSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/SurfaceSideSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,7 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -34,7 +34,8 @@ import androidx.compose.ui.unit.dp
 fun SurfaceSideSheet(
     showSheet: Boolean,
     onDismissSheet: () -> Unit,
-    isModal: Boolean = true, // <-- 新增 isModal 参数，默认为 true
+    isModal: Boolean = true,
+    sheetContainerColor: Color = MaterialTheme.colorScheme.surface,
     sheetContent: @Composable ColumnScope.() -> Unit,
     content: @Composable () -> Unit
 ) {
@@ -60,7 +61,6 @@ fun SurfaceSideSheet(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(scrimColor)
-                    // --- 修改部分 ---
                     // 仅在 isModal 为 true 时，才允许通过点击关闭
                     .then(if (isModal) {
                         Modifier.pointerInput(Unit) {
@@ -69,7 +69,6 @@ fun SurfaceSideSheet(
                     } else {
                         Modifier
                     })
-                // --- 修改结束 ---
             )
         }
 
@@ -93,8 +92,8 @@ fun SurfaceSideSheet(
                 .fillMaxHeight()
                 .width(sheetWidth)
                 .align(Alignment.CenterEnd)
-                .offset { offset }
-                .shadow(8.dp)
+                .offset { offset },
+            color = sheetContainerColor
         ) {
             Column(
                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -9,7 +9,6 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -34,7 +33,6 @@ import top.maary.emojiface.util.Constants
 import top.maary.emojiface.util.getFileNameWithoutExtensionUsingPath
 import top.maary.emojiface.util.getParcelableExtraCompat
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditScreenContentInternal(
     // Assuming Hilt provides the ViewModel with UseCases injected
@@ -200,7 +198,7 @@ fun EditScreenContentInternal(
                 tapPositionForAdd = offset
                 selectedIndexForEdit = -1 // Mark as Add
                 isAddMode = false // Exit add mode state after tap
-                viewModel.addEmoji(offset.x, offset.y, viewModel.getRandomEmoji(), 100f, 0f, startEditing = true)
+                viewModel.addEmoji(offset.x, offset.y, viewModel.getRandomEmoji(), 100f, 0f)
             },
             onImageContainerMeasured = { size -> imageContainerSize = size },
             onPickImageClick = {

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -9,6 +9,9 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -20,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -54,6 +58,8 @@ fun EditScreenContentInternal(
     var tapPositionForAdd by remember { mutableStateOf(Offset.Zero) } // Store tap position for adding
     var isEditingEmojiListInSheet by remember { mutableStateOf(false) } // State for bottom sheet mode
     var isMediumLayout by remember { mutableStateOf(false) } // To pass to ActionRow if needed
+    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
+    var emojiIndexToDelete by remember { mutableStateOf<Int?>(null) }
 
     // --- 3. Implement Launchers (No changes needed here) ---
     val photoPicker = rememberLauncherForActivityResult(
@@ -210,6 +216,10 @@ fun EditScreenContentInternal(
             onEmojiCardClick = { index ->
                 viewModel.startEditing(index)
             },
+            onEmojiCardLongClick = { index ->
+                emojiIndexToDelete = index
+                showDeleteConfirmDialog = true
+            },
             onAddEmojiCardClick = { isAddMode = true }, // Enter Add Mode
             onCloseClick = { activity?.finish() },
             // Share/Save now ignore the bitmap param internally in VM
@@ -250,6 +260,38 @@ fun EditScreenContentInternal(
             onCancelEditing = {
                 viewModel.cancelEditing()
             },
+        )
+    }
+
+    if (showDeleteConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showDeleteConfirmDialog = false
+                emojiIndexToDelete = null
+            },
+            title = { Text(stringResource(R.string.confirm_delete_title)) },
+            text = { Text(stringResource(R.string.confirm_delete_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        emojiIndexToDelete?.let { viewModel.removeEmoji(it) }
+                        showDeleteConfirmDialog = false
+                        emojiIndexToDelete = null
+                    }
+                ) {
+                    Text(stringResource(R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteConfirmDialog = false
+                        emojiIndexToDelete = null
+                    }
+                ) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
         )
     }
 

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -142,7 +142,8 @@ fun CompactScreenLayout(
                             Spacer(modifier = Modifier.width(8.dp))
                             EmojiCard(
                                 emoji = detection.emoji,
-                                onClick = { actions.onEmojiCardClick(index) }, // 使用 action
+                                onClick = { actions.onEmojiCardClick(index) },
+                                onLongClick = { actions.onEmojiCardLongClick(index) },
                                 fontFamily = state.fontFamily,
                                 containerColor = MaterialTheme.colorScheme.surfaceVariant,
                                 // hPadding 和 vPadding 使用 EmojiCard 的默認值或按需調整
@@ -347,7 +348,8 @@ fun LargeScreenLayout(
                                 itemsIndexed(state.emojiDetections) { index, detection ->
                                     EmojiCard(
                                         emoji = detection.emoji,
-                                        onClick = { actions.onEmojiCardClick(index) }, // Use action
+                                        onClick = { actions.onEmojiCardClick(index) },
+                                        onLongClick = { actions.onEmojiCardLongClick(index) },
                                         fontFamily = state.fontFamily,
                                         containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                         hPadding = 8.dp,

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -138,9 +138,13 @@ fun CompactScreenLayout(
                             vertical = 8.dp
                         ) // 增加垂直 padding
                     ) {
-                        itemsIndexed(state.emojiDetections) { index, detection ->
+                        itemsIndexed(
+                            items = state.emojiDetections,
+                            key = { _, item -> item.id } // key 使用 item 的唯一 id
+                        ) { index, detection ->
                             Spacer(modifier = Modifier.width(8.dp))
                             EmojiCard(
+                                modifier = Modifier.animateItem(),
                                 emoji = detection.emoji,
                                 onClick = { actions.onEmojiCardClick(index) },
                                 onLongClick = { actions.onEmojiCardLongClick(index) },
@@ -345,8 +349,12 @@ fun LargeScreenLayout(
                                 columns = GridCells.Adaptive(minSize = 76.dp), // Adaptive columns
                                 modifier = Modifier.weight(1f) // Grid takes available space
                             ) {
-                                itemsIndexed(state.emojiDetections) { index, detection ->
+                                itemsIndexed(
+                                    items = state.emojiDetections,
+                                    key = { _, item -> item.id } // key 使用 item 的唯一 id
+                                ) { index, detection ->
                                     EmojiCard(
+                                        modifier = Modifier.animateItem(),
                                         emoji = detection.emoji,
                                         onClick = { actions.onEmojiCardClick(index) },
                                         onLongClick = { actions.onEmojiCardLongClick(index) },

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
@@ -76,10 +77,9 @@ fun CompactScreenLayout(
         topBar = {
             CenterAlignedTopAppBar(
                 modifier = Modifier.shadow(8.dp), // 保留陰影
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.tertiary,
-                ),
+                    titleContentColor = MaterialTheme.colorScheme.tertiary),
                 title = {
                     // Compact 版本中標題為空
                 },
@@ -174,8 +174,6 @@ fun CompactScreenLayout(
     if (editingEmoji != null) {
         val bottomSheetState = rememberModalBottomSheetState(
             skipPartiallyExpanded = true,
-            // 只阻止用户将其关闭 (变为 Hidden)
-//            confirmValueChange = { it != SheetValue.Hidden }
         )
         val scope = rememberCoroutineScope()
 

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -54,8 +54,8 @@ import top.maary.emojiface.ui.components.DisplayPane
 import top.maary.emojiface.ui.components.EditEmojiBottomSheetContent
 import top.maary.emojiface.ui.components.EmojiCard
 import top.maary.emojiface.ui.components.SettingsBottomSheetContent
-import top.maary.emojiface.ui.components.SideSheet
 import top.maary.emojiface.ui.components.SideSheetContent
+import top.maary.emojiface.ui.components.SurfaceSideSheet
 import top.maary.emojiface.ui.edit.model.EmojiDetection
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
@@ -262,10 +262,10 @@ fun LargeScreenLayout(
     }
 
     // 3. 使用 AppSideSheet 容器，传入状态和内容
-    SideSheet(
+    SurfaceSideSheet (
         showSheet = showSideSheet,
         onDismissSheet = onDismiss,
-        isModal = (editingEmoji == null), // 编辑 emoji 时为 false，其他情况(设置)为 true
+        isModal = (editingEmoji == null),
         sheetContent = {
             SideSheetContent(
                 state = state,

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenLayout.kt
@@ -1,5 +1,6 @@
 package top.maary.emojiface.ui.edit // 或者你選擇的包名
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -184,6 +185,17 @@ fun CompactScreenLayout(
 
         val maxDiameter = state.currentImage?.let { minOf(it.width, it.height) / 3f } ?: 500f
 
+        var isSliding by remember { mutableStateOf(false) }
+
+        val containerColor by animateColorAsState(
+            targetValue = if (isSliding) {
+                MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.5f)
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
+            },
+            label = "BottomSheetColorAnimation"
+        )
+
         ModalBottomSheet(
             onDismissRequest = {
                 scope.launch {
@@ -194,7 +206,7 @@ fun CompactScreenLayout(
             sheetState = bottomSheetState,
             dragHandle = { },
             sheetGesturesEnabled = false,
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
+            containerColor = containerColor
         ) {
             // 完全复用现有的 Composable
             EditEmojiBottomSheetContent(
@@ -206,7 +218,8 @@ fun CompactScreenLayout(
                 onConfirm = actions.onConfirmEditing,
                 onDismiss = actions.onCancelEditing,
                 maxDiameter = maxDiameter,
-                onValueChange = actions.onEditingValueChanged
+                onValueChange = actions.onEditingValueChanged,
+                onSlidingStateChange = { isSliding = it }
             )
         }
     }
@@ -249,10 +262,19 @@ fun LargeScreenLayout(
     showSettingsSheet: Boolean,
     onDismissSettingsSheet: () -> Unit
 ) {
-    // 1. 逻辑更清晰：判断是否需要显示 SideSheet
     val showSideSheet = editingEmoji != null || showSettingsSheet
 
-    // 2. 决定关闭时应该执行哪个动作
+    var isSliding by remember { mutableStateOf(false) }
+
+    val sideSheetColor by animateColorAsState(
+        targetValue = if (isSliding) {
+            MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.5f)
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.9f)
+        },
+        label = "SideSheetColorAnimation"
+    )
+
     val onDismiss = {
         if (editingEmoji != null) {
             actions.onCancelEditing()
@@ -261,17 +283,18 @@ fun LargeScreenLayout(
         }
     }
 
-    // 3. 使用 AppSideSheet 容器，传入状态和内容
     SurfaceSideSheet (
         showSheet = showSideSheet,
         onDismissSheet = onDismiss,
         isModal = (editingEmoji == null),
+        sheetContainerColor = sideSheetColor,
         sheetContent = {
             SideSheetContent(
                 state = state,
                 actions = actions,
                 editingEmoji = editingEmoji,
-                showSettingsSheet = showSettingsSheet
+                showSettingsSheet = showSettingsSheet,
+                onSlidingStateChange = { isSliding = it }
             )
         }
     ) {

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -55,7 +54,6 @@ data class EditUiState(
     val editingEmoji: EmojiDetection? = null, // 正在编辑的 emoji 的瞬时数据
 )
 
-@OptIn(FlowPreview::class)
 @HiltViewModel
 class EmojiViewModel @Inject constructor(
     private val preferenceRepository: PreferenceRepository, // Keep for observing flows
@@ -123,7 +121,6 @@ class EmojiViewModel @Inject constructor(
                 Triple(paths, selectedPath, Pair(fontFamily, typeface))
             }.collect { (paths, selectedPath, fontPair) ->
                 val (fontFamily, typeface) = fontPair
-                val needsRerender = _uiState.value.selectedFontPath != selectedPath && _uiState.value.originalBitmap != null
                 _uiState.update { currentState ->
                     currentState.copy(
                         availableFontPaths = paths,
@@ -212,11 +209,7 @@ class EmojiViewModel @Inject constructor(
         val emojis = _uiState.value.selectedEmojis
         val font = _uiState.value.selectedFontPath
 
-        _uiState.update { it.copy(isRendering = true) }
-
         val result = renderEmojiOnBitmapUseCase(base, emojis, font)
-
-        _uiState.update { it.copy(isRendering = false) }
 
         return result.getOrNull()
     }
@@ -248,21 +241,36 @@ class EmojiViewModel @Inject constructor(
      */
     fun shareImage() {
         viewModelScope.launch {
-            val finalBitmap = renderFinalBitmap()
-            if (finalBitmap == null) {
-                _shareEvent.emit(ShareEvent.Error("Failed to render final image for sharing.", Constants.STATUS_SHARE))
-                return@launch
-            }
-
-            generateShareableUriUseCase(finalBitmap).fold(
-                onSuccess = { uri ->
-                    _shareEvent.emit(ShareEvent.ShareImage(uri))
-                },
-                onFailure = { exception ->
-                    exception.localizedMessage?.let { ShareEvent.Error(message = it, status = Constants.STATUS_SHARE) }
-                        ?.let { _shareEvent.emit(it) }
+            _uiState.update { it.copy(isRendering = true) }
+            try {
+                val finalBitmap = renderFinalBitmap()
+                if (finalBitmap == null) {
+                    _shareEvent.emit(
+                        ShareEvent.Error(
+                            "Failed to render final image for sharing.",
+                            Constants.STATUS_SHARE
+                        )
+                    )
+                    return@launch
                 }
-            )
+
+                generateShareableUriUseCase(finalBitmap).fold(
+                    onSuccess = { uri ->
+                        _shareEvent.emit(ShareEvent.ShareImage(uri))
+                    },
+                    onFailure = { exception ->
+                        exception.localizedMessage?.let {
+                            ShareEvent.Error(
+                                message = it,
+                                status = Constants.STATUS_SHARE
+                            )
+                        }
+                            ?.let { _shareEvent.emit(it) }
+                    }
+                )
+            } finally {
+                _uiState.update { it.copy(isRendering = false) }
+            }
         }
     }
 
@@ -272,21 +280,36 @@ class EmojiViewModel @Inject constructor(
      */
     fun saveImageToGallery() {
         viewModelScope.launch {
-            val finalBitmap = renderFinalBitmap()
-            if (finalBitmap == null) {
-                _shareEvent.emit(ShareEvent.Error("Failed to render final image for saving.", Constants.STATUS_SAVE))
-                return@launch
-            }
-
-            saveImageUseCase(finalBitmap).fold(
-                onSuccess = {
-                    _shareEvent.emit(ShareEvent.Success(Constants.STATUS_SAVE))
-                },
-                onFailure = { exception ->
-                    exception.localizedMessage?.let { ShareEvent.Error(message = it, status = Constants.STATUS_SAVE) }
-                        ?.let { _shareEvent.emit(it) }
+            _uiState.update { it.copy(isRendering = true) }
+            try {
+                val finalBitmap = renderFinalBitmap()
+                if (finalBitmap == null) {
+                    _shareEvent.emit(
+                        ShareEvent.Error(
+                            "Failed to render final image for saving.",
+                            Constants.STATUS_SAVE
+                        )
+                    )
+                    return@launch
                 }
-            )
+
+                saveImageUseCase(finalBitmap).fold(
+                    onSuccess = {
+                        _shareEvent.emit(ShareEvent.Success(Constants.STATUS_SAVE))
+                    },
+                    onFailure = { exception ->
+                        exception.localizedMessage?.let {
+                            ShareEvent.Error(
+                                message = it,
+                                status = Constants.STATUS_SAVE
+                            )
+                        }
+                            ?.let { _shareEvent.emit(it) }
+                    }
+                )
+            } finally {
+                _uiState.update { it.copy(isRendering = false) }
+            }
         }
     }
 
@@ -301,32 +324,10 @@ class EmojiViewModel @Inject constructor(
     // --- Emoji Manipulation ---
 
     /**
-     * Updates an existing emoji's properties or removes it if newEmoji is empty.
-     * (Signature matches original)
-     */
-    fun updateEmoji(index: Int, newEmoji: String, newDiameter: Float, newAngle: Float) {
-        val currentList = _uiState.value.selectedEmojis.toMutableList()
-        if (index < 0 || index >= currentList.size) {
-            _uiState.update { it.copy(errorMessage = "Invalid index for updating emoji.") }
-            return
-        }
-
-        if (newEmoji.isEmpty()) { // Remove emoji if empty string is passed
-            currentList.removeAt(index)
-        } else {
-            val updated = currentList[index].copy(emoji = newEmoji, diameter = newDiameter, angle = newAngle)
-            currentList[index] = updated
-        }
-
-        _uiState.update { it.copy(selectedEmojis = currentList) }
-        rerenderBitmap() // Re-render after modification
-    }
-
-    /**
      * Adds a new emoji at the specified coordinates.
      * (Signature matches original)
      */
-    fun addEmoji(x: Float, y: Float, emoji: String, diameter: Float, angle: Float, startEditing: Boolean = false) {
+    fun addEmoji(x: Float, y: Float, emoji: String, diameter: Float, angle: Float) {
         if (_uiState.value.originalBitmap == null) {
             _uiState.update { it.copy(errorMessage = "Cannot add emoji without an image.") }
             return
@@ -397,38 +398,6 @@ class EmojiViewModel @Inject constructor(
     fun cancelEditing() {
         _uiState.update { it.copy(editingEmoji = null, editingEmojiIndex = null) }
         editingStateFlow.value = null
-    }
-
-    /**
-     * 私有的重绘方法，用于实时预览
-     */
-    private fun rerenderWithTransientEdit() {
-        val base = _uiState.value.originalBitmap ?: return
-        val emojis = _uiState.value.selectedEmojis.toMutableList()
-        val editingEmoji = _uiState.value.editingEmoji
-        val editingIndex = _uiState.value.editingEmojiIndex
-
-        if (editingEmoji != null && editingIndex != null && editingIndex in emojis.indices) {
-            emojis[editingIndex] = editingEmoji // 将正在编辑的 emoji 替换到列表中用于预览
-        } else {
-            return // 如果没有正在编辑的对象，则不重绘
-        }
-
-        val font = _uiState.value.selectedFontPath
-
-        // ... 接续 rerenderBitmap 的原有逻辑，但使用上面构造的临时 emojis 列表
-        viewModelScope.launch {
-            _uiState.update { it.copy(isRendering = true) }
-            renderEmojiOnBitmapUseCase(base, emojis, font).fold(
-                onSuccess = { newBitmap ->
-                    _uiState.update { it.copy(processedBitmap = newBitmap, isRendering = false, errorMessage = null) }
-                },
-                onFailure = { exception ->
-                    _uiState.update { it.copy(isRendering = false, errorMessage = "Re-rendering failed: ${exception.localizedMessage}") }
-                }
-                // ... success/failure handling
-            )
-        }
     }
 
     // --- Settings Related ---
@@ -516,34 +485,5 @@ class EmojiViewModel @Inject constructor(
     /** Clears the current success message from the state */
     fun clearSuccessMessage() {
         _uiState.update { it.copy(successMessage = null) }
-    }
-
-
-    // --- Private Helper ---
-
-    /**
-     * Re-renders the processed image based on the current original bitmap,
-     * selected emojis, and selected font. Updates the state accordingly.
-     */
-    private fun rerenderBitmap() {
-        val base = _uiState.value.originalBitmap
-            ?: // Cannot rerender without original image
-            // Log.w("EditViewModel", "Cannot rerender: Original bitmap is null.")
-            return
-        val emojis = _uiState.value.selectedEmojis
-        val font = _uiState.value.selectedFontPath
-
-        _uiState.update { it.copy(isRendering = true) } // Indicate re-rendering start
-
-        viewModelScope.launch {
-            renderEmojiOnBitmapUseCase(base, emojis, font).fold(
-                onSuccess = { newBitmap ->
-                    _uiState.update { it.copy(processedBitmap = newBitmap, isRendering = false, errorMessage = null) }
-                },
-                onFailure = { exception ->
-                    _uiState.update { it.copy(isRendering = false, errorMessage = "Re-rendering failed: ${exception.localizedMessage}") }
-                }
-            )
-        }
     }
 }

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EmojiViewModel.kt
@@ -82,16 +82,6 @@ class EmojiViewModel @Inject constructor(
     init {
         // Observe preferences and update state
         observePreferences()
-//        viewModelScope.launch {
-//            editingStateFlow
-//                .debounce(50L) // 防抖，用户停止滑动50毫秒后再触发
-//                .collect { emoji ->
-//                    if (emoji != null) {
-//                        // 当有稳定的编辑中状态时，触发重绘
-//                        rerenderWithTransientEdit()
-//                    }
-//                }
-//        }
     }
 
     private fun observePreferences() {
@@ -345,6 +335,17 @@ class EmojiViewModel @Inject constructor(
     }
 
     /**
+     * Removes an emoji from the list by its index.
+     */
+    fun removeEmoji(index: Int) {
+        val currentList = _uiState.value.selectedEmojis.toMutableList()
+        if (index >= 0 && index < currentList.size) {
+            currentList.removeAt(index)
+            _uiState.update { it.copy(selectedEmojis = currentList) }
+        }
+    }
+
+    /**
      * 开始编辑一个 Emoji
      */
     fun startEditing(index: Int) {
@@ -379,12 +380,21 @@ class EmojiViewModel @Inject constructor(
         val transientIndex = _uiState.value.editingEmojiIndex
         val currentList = _uiState.value.selectedEmojis.toMutableList()
 
-        if (transientIndex != null && transientIndex == -1) {
-            // 情况2：这是一个新的 Emoji，现在将它添加到主列表中
-            currentList.add(transientEmoji)
-        } else if (transientIndex != null && transientIndex >= 0 && transientIndex < currentList.size) {
-            // 情况1：这是一个已存在的 Emoji，更新它
-            currentList[transientIndex] = transientEmoji
+        if (transientEmoji.emoji.isEmpty()) {
+            // This is a delete operation. Only delete if it's an existing emoji.
+            if (transientIndex != null && transientIndex >= 0 && transientIndex < currentList.size) {
+                currentList.removeAt(transientIndex)
+            }
+            // If it was a new emoji, clearing text is just a cancel, so we do nothing.
+        } else {
+            // This is an add or update operation.
+            if (transientIndex != null && transientIndex >= 0 && transientIndex < currentList.size) {
+                // Update existing emoji
+                currentList[transientIndex] = transientEmoji
+            } else if (transientIndex != null && transientIndex == -1) {
+                // Add new emoji
+                currentList.add(transientEmoji)
+            }
         }
 
         // 清除瞬时编辑状态

--- a/app/src/main/java/top/maary/emojiface/ui/edit/model/EmojiDetection.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/model/EmojiDetection.kt
@@ -1,6 +1,9 @@
 package top.maary.emojiface.ui.edit.model
 
+import kotlin.random.Random
+
 data class EmojiDetection(
+    val id: Long = (System.currentTimeMillis() shl 20) or (Random.nextLong(0, 1L shl 20)),
     val xCenter: Float,
     val yCenter: Float,
     val diameter: Float,

--- a/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenActions.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/state/EditScreenActions.kt
@@ -22,6 +22,8 @@ data class EditScreenActions(
     val onEmojiCardClick: (index: Int) -> Unit,
     /** 當使用者點擊「新增」的 EmojiCard 時呼叫。 */
     val onAddEmojiCardClick: () -> Unit,
+    /** 當使用者長按現有的 EmojiCard 時呼叫，傳遞其索引以进行删除。 */
+    val onEmojiCardLongClick: (index: Int) -> Unit,
 
     // --- 主要導覽和動作按鈕 ---
     /** 當使用者點擊「關閉/退出」按鈕時呼叫。 */
@@ -33,7 +35,7 @@ data class EditScreenActions(
     /** 當使用者點擊「設定」按鈕時呼叫 (通常用於打開底部工作表)。 */
     val onSettingsClick: () -> Unit,
 
-    // --- 实时编辑表情符號操作 (替换原有 Dialog 操作) ---
+    // --- 实时编辑表情符號操作 ---
     /** 当用户在实时编辑时，参数发生了变化 */
     val onEditingValueChanged: (emoji: String? , diameter: Float?, rotation: Float?) -> Unit,
     /** 当用户确认实时编辑的结果时调用 */

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -25,4 +25,6 @@
     <string name="created_by">此照片經過 FaceMoji 編輯。</string>
     <string name="emoji_list">Emoji 列表</string>
     <string name="emoji_font">Emoji 字體</string>
+    <string name="confirm_delete_title">確認刪除</string>
+    <string name="confirm_delete_message">您確定要刪除這個表情符號嗎？</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -26,4 +26,6 @@
     <string name="created_by">此照片经过 FaceMoji 编辑。</string>
     <string name="emoji_list">Emoji 列表</string>
     <string name="emoji_font">Emoji 字体</string>
+    <string name="confirm_delete_title">确认删除</string>
+    <string name="confirm_delete_message">您确定要删除这个表情符号吗？</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,6 @@
     <string name="created_by">Modified by FaceMoji.</string>
     <string name="emoji_list">Emoji List</string>
     <string name="emoji_font">Emoji Font</string>
+    <string name="confirm_delete_title">Confirm Deletion</string>
+    <string name="confirm_delete_message">Are you sure you want to delete this emoji?</string>
 </resources>


### PR DESCRIPTION
This commit introduces a new interaction model to the application, enabling users to delete an emoji by long-pressing its corresponding card. To prevent accidental actions, this operation triggers a confirmation dialog for user verification.

To support this functionality and refine the user experience, several UI components have been refactored and enhanced. Notably, for large-screen layouts, the existing side sheet has been replaced by a custom `SurfaceSideSheet` component to allow for more precise control over its animation and behavior. A new visual feedback mechanism has also been added to the editing panels (both the bottom sheet and side sheet); their backgrounds become semi-transparent when the user drags the size or angle sliders. This indicates an active editing state and improves the visibility of the underlying image.

Additionally, this update includes improvements to the codebase structure. The `ResultImg` component has been decoupled to have a more specific responsibility. State management in the `EmojiViewModel` was simplified by removing a previous debounce-based live-rendering mechanism. Finally, to support smoother list animations, a unique `id` field has been added to the `EmojiDetection` data model.
