### PR TITLE
Fix persistence on Android Firefox: Flush on unload & optimize I/O

### DIFF
--- a/web/src/infrastructure/PersistenceRepository.ts
+++ b/web/src/infrastructure/PersistenceRepository.ts
@@ -21,7 +21,7 @@ class PersistenceRepository {
   }
 
   async saveState(
-    image: Blob | null,
+    image: Blob | null | undefined,
     detections: Detection[],
     masks: Mask[],
     settings: Partial<AppSettings> | any // Using any for now to store generic settings like randomEmojiList
@@ -29,15 +29,17 @@ class PersistenceRepository {
     const db = await this.getDB();
     const tx = db.transaction(STORE_NAME, 'readwrite');
 
-    // We save items individually to allow partial updates if needed,
-    // but for now we just save everything at once.
-    await Promise.all([
-      tx.store.put(image, 'image'),
+    const promises: Promise<unknown>[] = [
       tx.store.put(detections, 'detections'),
       tx.store.put(masks, 'masks'),
       tx.store.put(settings, 'settings'),
-      tx.done
-    ]);
+    ];
+
+    if (image !== undefined) {
+      promises.push(tx.store.put(image, 'image'));
+    }
+
+    await Promise.all([...promises, tx.done]);
   }
 
   async loadState() {

--- a/web/src/store/editorStore.ts
+++ b/web/src/store/editorStore.ts
@@ -238,6 +238,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     }
 
     if (state.image) {
+        lastSavedImageBlob = state.image; // Sync last saved image
         const bitmap = await createImageBitmap(state.image);
         set({
             image: bitmap,
@@ -314,21 +315,47 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
 // Subscription for persistence
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
+let lastSavedImageBlob: Blob | null = null;
+
+const performSave = (state: EditorState) => {
+    // Only save image if it has changed
+    const imageToSave = state.imageBlob !== lastSavedImageBlob ? state.imageBlob : undefined;
+
+    // Update reference if we are saving a new image
+    if (imageToSave !== undefined) {
+        lastSavedImageBlob = imageToSave;
+    }
+
+    persistenceRepo.saveState(
+        imageToSave,
+        state.detections,
+        state.masks,
+        {
+            randomEmojiList: state.randomEmojiList,
+            currentMaskType: state.currentMaskType,
+            currentBlurType: state.currentBlurType,
+            currentEmoji: state.currentEmoji,
+            currentFont: state.currentFont
+        }
+    );
+};
 
 useEditorStore.subscribe((state) => {
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
-        persistenceRepo.saveState(
-            state.imageBlob,
-            state.detections,
-            state.masks,
-            {
-                randomEmojiList: state.randomEmojiList,
-                currentMaskType: state.currentMaskType,
-                currentBlurType: state.currentBlurType,
-                currentEmoji: state.currentEmoji,
-                currentFont: state.currentFont
-            }
-        );
+        saveTimer = null;
+        performSave(state);
     }, 500);
 });
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+            if (saveTimer) {
+                clearTimeout(saveTimer);
+                saveTimer = null;
+                performSave(useEditorStore.getState());
+            }
+        }
+    });
+}


### PR DESCRIPTION
This PR addresses an issue where setting changes were lost on Android Firefox when refreshing the page shortly after modification.

Changes:
1.  **Flush on Unload/Visibility Change:** Added a `visibilitychange` listener in `editorStore.ts` to immediately execute any pending save operations when the page becomes hidden (e.g., during refresh or tab switch), preventing the debounce timer from being cleared without saving.
2.  **Optimized Persistence:** Modified `PersistenceRepository.ts` to support partial updates, specifically allowing the `image` argument to be `undefined`.
3.  **Differential Saving:** Updated `editorStore.ts` to track `lastSavedImageBlob` and only pass the image to the repository if it has actually changed. This significantly reduces I/O overhead for simple setting changes, making the flush operation faster and more reliable.

Verification:
- Confirmed type safety via `npm run build`.
- Addressed linting issues.
- Code review confirmed the logic addresses the root cause (debounce + slow I/O).

---
*PR created automatically by Jules for task [15530079489145945785](https://jules.google.com/task/15530079489145945785) started by @Steve-Mr*