### PR TITLE
Improve random emoji assignment to prevent duplicates

### DIFF
--- a/web/src/store/editorStore.ts
+++ b/web/src/store/editorStore.ts
@@ -160,9 +160,15 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       }
       const detections = await faceDetector.detect(image);
 
-      const masks: Mask[] = detections.map(d => {
-        const emoji = randomEmojiList.length > 0
-            ? randomEmojiList[Math.floor(Math.random() * randomEmojiList.length)]
+      const shuffledEmojis = [...randomEmojiList];
+      for (let i = shuffledEmojis.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [shuffledEmojis[i], shuffledEmojis[j]] = [shuffledEmojis[j], shuffledEmojis[i]];
+      }
+
+      const masks: Mask[] = detections.map((d, index) => {
+        const emoji = shuffledEmojis.length > 0
+            ? shuffledEmojis[index % shuffledEmojis.length]
             : '😊';
 
         return {
@@ -273,8 +279,12 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           keypoints: []
       };
 
-      const emoji = randomEmojiList.length > 0
-          ? randomEmojiList[Math.floor(Math.random() * randomEmojiList.length)]
+      const usedEmojis = new Set(get().masks.map(m => m.config.emoji));
+      const availableEmojis = randomEmojiList.filter(e => !usedEmojis.has(e));
+      const pool = availableEmojis.length > 0 ? availableEmojis : randomEmojiList;
+
+      const emoji = pool.length > 0
+          ? pool[Math.floor(Math.random() * pool.length)]
           : '😊';
 
       const newMask: Mask = {

--- a/web/src/store/editorStore.ts
+++ b/web/src/store/editorStore.ts
@@ -47,6 +47,15 @@ export interface EditorState {
   deleteMask: (id: string) => void;
 }
 
+const shuffleArray = <T>(array: T[]): T[] => {
+    const newArray = [...array];
+    for (let i = newArray.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+    }
+    return newArray;
+};
+
 const calculateRotation = (keypoints: {x: number, y: number}[]) => {
     if (!keypoints || keypoints.length < 2) return 0;
     const leftEye = keypoints[0];
@@ -160,11 +169,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       }
       const detections = await faceDetector.detect(image);
 
-      const shuffledEmojis = [...randomEmojiList];
-      for (let i = shuffledEmojis.length - 1; i > 0; i--) {
-          const j = Math.floor(Math.random() * (i + 1));
-          [shuffledEmojis[i], shuffledEmojis[j]] = [shuffledEmojis[j], shuffledEmojis[i]];
-      }
+      const shuffledEmojis = shuffleArray(randomEmojiList);
 
       const masks: Mask[] = detections.map((d, index) => {
         const emoji = shuffledEmojis.length > 0
@@ -279,7 +284,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           keypoints: []
       };
 
-      const usedEmojis = new Set(get().masks.map(m => m.config.emoji));
+      const usedEmojis = new Set(get().masks.map(m => m.config.emoji).filter((e): e is string => !!e));
       const availableEmojis = randomEmojiList.filter(e => !usedEmojis.has(e));
       const pool = availableEmojis.length > 0 ? availableEmojis : randomEmojiList;
 


### PR DESCRIPTION
Refactored the emoji assignment logic in `editorStore.ts` to prevent duplicates.
1. Batch generation: Shuffles the list and assigns sequentially.
2. Manual generation: Filters out already used emojis before randomly selecting from the pool.

---
*PR created automatically by Jules for task [157863292068831769](https://jules.google.com/task/157863292068831769) started by @Steve-Mr*