### PR TITLE
feat: handle subsequent shared images with a replacement prompt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         minSdk = 30
         targetSdk = 36
         versionCode = 2
-        versionName = "2026.07.14"
+        versionName = "2026.08.02"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.EmojiFace">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/java/top/maary/emojiface/MainActivity.kt
+++ b/app/src/main/java/top/maary/emojiface/MainActivity.kt
@@ -1,22 +1,43 @@
 package top.maary.emojiface
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.util.Consumer
 import dagger.hilt.android.AndroidEntryPoint
 import top.maary.emojiface.ui.edit.EditScreen
 import top.maary.emojiface.ui.theme.EmojiFaceTheme
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import androidx.lifecycle.lifecycleScope
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private val _newIntents = MutableSharedFlow<Intent>(replay = 1)
+    val newIntents = _newIntents.asSharedFlow()
+
+    private val intentListener = Consumer<Intent> { intent ->
+        lifecycleScope.launch {
+            _newIntents.emit(intent)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        addOnNewIntentListener(intentListener)
         setContent {
             EmojiFaceTheme {
                 EditScreen()
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        removeOnNewIntentListener(intentListener)
     }
 }

--- a/app/src/main/java/top/maary/emojiface/ui/components/ReplaceImageBottomSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/ReplaceImageBottomSheet.kt
@@ -1,0 +1,131 @@
+package top.maary.emojiface.ui.components
+
+import android.net.Uri
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import top.maary.emojiface.R
+import java.io.InputStream
+import top.maary.emojiface.util.ExifUtils
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReplaceImageBottomSheet(
+    newUri: Uri?,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    if (newUri != null) {
+        val context = LocalContext.current
+        var bitmap by remember(newUri) { mutableStateOf<android.graphics.Bitmap?>(null) }
+
+        LaunchedEffect(newUri) {
+            withContext(Dispatchers.IO) {
+                try {
+                    // downsample bitmap to avoid OOM
+                    val options = BitmapFactory.Options().apply {
+                        inJustDecodeBounds = true
+                    }
+                    context.contentResolver.openInputStream(newUri)?.use { stream ->
+                        BitmapFactory.decodeStream(stream, null, options)
+                    }
+
+                    options.inSampleSize = calculateInSampleSize(options, 500, 500)
+                    options.inJustDecodeBounds = false
+
+                    val decodedBitmap = context.contentResolver.openInputStream(newUri)?.use { stream ->
+                        BitmapFactory.decodeStream(stream, null, options)
+                    }
+
+                    decodedBitmap?.let { bmp ->
+                        bitmap = ExifUtils.handleImageOrientation(context, newUri, bmp)
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+        }
+
+        ModalBottomSheet(
+            onDismissRequest = onDismissRequest,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(id = R.string.replace_image_title),
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                bitmap?.let {
+                    Image(
+                        bitmap = it.asImageBitmap(),
+                        contentDescription = "New shared image preview",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 200.dp)
+                            .clip(RoundedCornerShape(8.dp)),
+                        contentScale = ContentScale.Fit
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+
+                Text(
+                    text = stringResource(id = R.string.replace_image_message),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = onDismissRequest) {
+                        Text(text = stringResource(id = R.string.cancel))
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(onClick = {
+                        onConfirm()
+                        onDismissRequest()
+                    }) {
+                        Text(text = stringResource(id = R.string.replace))
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
+    val (height: Int, width: Int) = options.outHeight to options.outWidth
+    var inSampleSize = 1
+
+    if (height > reqHeight || width > reqWidth) {
+        val halfHeight: Int = height / 2
+        val halfWidth: Int = width / 2
+
+        while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+            inSampleSize *= 2
+        }
+    }
+
+    return inSampleSize
+}

--- a/app/src/main/java/top/maary/emojiface/ui/components/ReplaceImageBottomSheet.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/components/ReplaceImageBottomSheet.kt
@@ -1,12 +1,31 @@
 package top.maary.emojiface.ui.components
 
-import android.net.Uri
 import android.graphics.BitmapFactory
+import android.net.Uri
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -18,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import top.maary.emojiface.R
-import java.io.InputStream
 import top.maary.emojiface.util.ExifUtils
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreen.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreen.kt
@@ -11,6 +11,3 @@ fun EditScreen(emojiViewModel: EmojiViewModel = viewModel(),
     EditScreenContentInternal(emojiViewModel, windowSizeClass)
 
 }
-
-
-

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -18,25 +18,26 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntSize
+import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.flow.collectLatest
+import top.maary.emojiface.MainActivity
 import top.maary.emojiface.R
+import top.maary.emojiface.ui.components.ReplaceImageBottomSheet
 import top.maary.emojiface.ui.edit.state.EditScreenActions
 import top.maary.emojiface.ui.edit.state.EditScreenState
 import top.maary.emojiface.ui.edit.state.ShareEvent
 import top.maary.emojiface.util.Constants
 import top.maary.emojiface.util.getFileNameWithoutExtensionUsingPath
 import top.maary.emojiface.util.getParcelableExtraCompat
-import top.maary.emojiface.ui.components.ReplaceImageBottomSheet
-import top.maary.emojiface.MainActivity
 
 @Composable
 fun EditScreenContentInternal(
@@ -61,7 +62,7 @@ fun EditScreenContentInternal(
 
     // Use rememberSaveable to persist the uri across rotation
     var newSharedUriString by rememberSaveable { mutableStateOf<String?>(null) }
-    val newSharedUri = remember(newSharedUriString) { newSharedUriString?.let { Uri.parse(it) } }
+    val newSharedUri = remember(newSharedUriString) { newSharedUriString?.toUri() }
 
     var pickerLaunchedOnMain by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
+++ b/app/src/main/java/top/maary/emojiface/ui/edit/EditScreenContentInternal.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -34,6 +35,8 @@ import top.maary.emojiface.ui.edit.state.ShareEvent
 import top.maary.emojiface.util.Constants
 import top.maary.emojiface.util.getFileNameWithoutExtensionUsingPath
 import top.maary.emojiface.util.getParcelableExtraCompat
+import top.maary.emojiface.ui.components.ReplaceImageBottomSheet
+import top.maary.emojiface.MainActivity
 
 @Composable
 fun EditScreenContentInternal(
@@ -43,6 +46,7 @@ fun EditScreenContentInternal(
 ) {
     val context = LocalContext.current
     val activity = context as? Activity
+    val mainActivity = activity as? MainActivity
 
     // --- 1. Observe ViewModel's Single State Flow ---
     // Use collectAsStateWithLifecycle for better lifecycle awareness
@@ -55,18 +59,22 @@ fun EditScreenContentInternal(
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }
     var emojiIndexToDelete by remember { mutableStateOf<Int?>(null) }
 
+    // Use rememberSaveable to persist the uri across rotation
+    var newSharedUriString by rememberSaveable { mutableStateOf<String?>(null) }
+    val newSharedUri = remember(newSharedUriString) { newSharedUriString?.let { Uri.parse(it) } }
+
     var pickerLaunchedOnMain by remember { mutableStateOf(false) }
 
     // --- 3. Implement Launchers (No changes needed here) ---
     val photoPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia()
     ) { uri ->
-        uri?.let { viewModel.detect(it) } // Call VM method
+        uri?.let { viewModel.detect(it) }
     }
 
     val filePicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
-    ) { uri ->
+    ) { uri: Uri? ->
         uri?.let { viewModel.copyFontToInternal(it) } // Call VM method
     }
 
@@ -100,17 +108,36 @@ fun EditScreenContentInternal(
 
     // --- 4. Implement Effects ---
 
-    // Handle incoming ACTION_SEND intent (No changes needed here)
+    // Handle incoming ACTION_SEND intent initially
     LaunchedEffect(activity?.intent) {
         val intent = activity?.intent
-        if (intent?.action == Intent.ACTION_SEND && intent.type?.startsWith("image/") == true) {
+        // Only trigger if we have an intent and we haven't already shown a prompt for it.
+        // We use newSharedUri as a guard to not show the sheet multiple times on rotation.
+        if (intent?.action == Intent.ACTION_SEND && intent.type?.startsWith("image/") == true && newSharedUri == null) {
             val sharedUri: Parcelable? = intent.getParcelableExtraCompat(Intent.EXTRA_STREAM)
-            (sharedUri as? Uri)?.let {
-                // Check if already processed (using uiState.originalBitmap as indicator)
+            (sharedUri as? Uri)?.let { uri ->
                 if (uiState.originalBitmap == null) {
-                    viewModel.detect(it)
+                    viewModel.detect(uri)
+                } else {
+                    newSharedUriString = uri.toString()
                 }
-                intent.action = null // Prevent re-processing
+                intent.action = null // Prevent re-processing on rotation
+            }
+        }
+    }
+
+    LaunchedEffect(mainActivity) {
+        mainActivity?.newIntents?.collectLatest { intent ->
+            if (intent.action == Intent.ACTION_SEND && intent.type?.startsWith("image/") == true) {
+                val sharedUri: Parcelable? = intent.getParcelableExtraCompat(Intent.EXTRA_STREAM)
+                (sharedUri as? Uri)?.let { uri ->
+                    if (uiState.originalBitmap == null) {
+                        viewModel.detect(uri)
+                    } else {
+                        newSharedUriString = uri.toString()
+                    }
+                    intent.action = null
+                }
             }
         }
     }
@@ -142,10 +169,7 @@ fun EditScreenContentInternal(
                         }
                     }
 
-                    // 统一显示 Toast
-                    if (messageToShow.isNotEmpty()) {
-                        Toast.makeText(context, messageToShow, Toast.LENGTH_SHORT).show()
-                    }
+                    Toast.makeText(context, messageToShow, Toast.LENGTH_SHORT).show()
                 }
                 is ShareEvent.Success -> { // Handle potential success messages
                     if (event.status == Constants.STATUS_SAVE) {
@@ -330,6 +354,13 @@ fun EditScreenContentInternal(
         )
     }
 
+    ReplaceImageBottomSheet(
+        newUri = newSharedUri,
+        onDismissRequest = { newSharedUriString = null },
+        onConfirm = {
+            newSharedUri?.let { viewModel.detect(it) }
+        }
+    )
 
     // --- 8. Layout Dispatching ---
     when {

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -40,4 +40,7 @@
     <string name="face">臉部</string>
     <string name="eyes">眼部</string>
     <string name="mosaic_target">目標</string>
+    <string name="replace_image_title">替換目前圖片？</string>
+    <string name="replace_image_message">是否使用新分享的圖片替換目前正在編輯的圖片？</string>
+    <string name="replace">替換</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -41,4 +41,7 @@
     <string name="face">面部</string>
     <string name="eyes">眼部</string>
     <string name="mosaic_target">目标</string>
+    <string name="replace_image_title">替换当前图片？</string>
+    <string name="replace_image_message">是否使用新分享的图片替换当前正在编辑的图片？</string>
+    <string name="replace">替换</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,7 @@
     <string name="face">Face</string>
     <string name="eyes">Eyes</string>
     <string name="mosaic_target">Target</string>
+    <string name="replace_image_title">Replace Current Image?</string>
+    <string name="replace_image_message">Do you want to replace the current image with the newly shared one? Your current edits will be lost.</string>
+    <string name="replace">Replace</string>
 </resources>


### PR DESCRIPTION
This PR implements the requested behavior for Android app image sharing. Previously, if the app was already editing an image, sharing a second image to the app did nothing. Now, it intercepts the new intent and shows a Bottom Sheet prompting the user to replace the current image, complete with a preview of the new image.

---
*PR created automatically by Jules for task [10687789826828103078](https://jules.google.com/task/10687789826828103078) started by @Steve-Mr*